### PR TITLE
Fix notify IV0 not working

### DIFF
--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -478,7 +478,7 @@ function isNotifPokemon(pokemon) {
     }
 
     if (settings.showPokemonValues) {
-        if (pokemon.individual_attack && settings.pokemonValuesNotifs && settings.notifValuesPokemon.has(pokemon.pokemon_id)) {
+        if (pokemon.weight && settings.pokemonValuesNotifs && settings.notifValuesPokemon.has(pokemon.pokemon_id)) {
             const ivsPercentage = getIvsPercentage(pokemon.individual_attack, pokemon.individual_defense, pokemon.individual_stamina)
             const level = getPokemonLevel(pokemon.cp_multiplier)
             if ((ivsPercentage >= settings.minNotifIvs || (settings.zeroIvsPokemonNotifs && ivsPercentage === 0)) &&

--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -24,7 +24,7 @@ function isPokemonMeetsFilters(pokemon, isNotifPokemon) {
     }
 
     if (settings.showPokemonValues && settings.filterPokemonByValues && !settings.noFilterValuesPokemon.has(pokemon.pokemon_id)) {
-        if (pokemon.individual_attack !== null) {
+        if (pokemon.individual_attack != null) {
             const ivsPercentage = getIvsPercentage(pokemon.individual_attack, pokemon.individual_defense, pokemon.individual_stamina)
             if (ivsPercentage < settings.minIvs && !(settings.showZeroIvsPokemon && ivsPercentage === 0)) {
                 return false
@@ -411,7 +411,7 @@ function updatePokemon(id, pokemon = null) {
 function updatePokemons(pokemonIds = new Set(), encounteredOnly = false) {
     if (pokemonIds.size > 0 && encounteredOnly) {
         $.each(mapData.pokemons, function (encounterId, pokemon) {
-            if (pokemonIds.has(pokemon.pokemon_id) && pokemon.individual_attack !== null) {
+            if (pokemonIds.has(pokemon.pokemon_id) && pokemon.individual_attack != null) {
                 updatePokemon(encounterId)
             }
         })
@@ -423,7 +423,7 @@ function updatePokemons(pokemonIds = new Set(), encounteredOnly = false) {
         })
     } else if (encounteredOnly) {
         $.each(mapData.pokemons, function (encounterId, pokemon) {
-            if (pokemon.individual_attack !== null) {
+            if (pokemon.individual_attack != null) {
                 updatePokemon(encounterId)
             }
         })
@@ -559,7 +559,7 @@ function sendPokemonNotification(pokemon) {
 
         notifText = `Disappears at ${expireTime} (${expireTimeCountdown})`
 
-        if (settings.showPokemonValues && pokemon.individual_attack !== null) {
+        if (settings.showPokemonValues && pokemon.individual_attack != null) {
             const ivsPercentage = getIvsPercentage(pokemon.individual_attack, pokemon.individual_defense, pokemon.individual_stamina)
             notifTitle += ` ${ivsPercentage}% (${pokemon.individual_attack}/${pokemon.individual_defense}/${pokemon.individual_stamina}) L${getPokemonLevel(pokemon.cp_multiplier)}`
             const move1 = getMoveName(pokemon.move_1)

--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -478,7 +478,7 @@ function isNotifPokemon(pokemon) {
     }
 
     if (settings.showPokemonValues) {
-        if (pokemon.weight && settings.pokemonValuesNotifs && settings.notifValuesPokemon.has(pokemon.pokemon_id)) {
+        if (pokemon.individual_attack != null && settings.pokemonValuesNotifs && settings.notifValuesPokemon.has(pokemon.pokemon_id)) {
             const ivsPercentage = getIvsPercentage(pokemon.individual_attack, pokemon.individual_defense, pokemon.individual_stamina)
             const level = getPokemonLevel(pokemon.cp_multiplier)
             if ((ivsPercentage >= settings.minNotifIvs || (settings.zeroIvsPokemonNotifs && ivsPercentage === 0)) &&


### PR DESCRIPTION


Notify IV0 not working 

## Description
pokemon.individual_attack is not good test for verify if information IV is present. 
pokemon.individual_attack egal 0 in 1/16 case and allways for IV0 .  
Check weight is allways defined with IV

## Motivation and Context
Check weight is allways defined with IV

## How Has This Been Tested?
Yes . Results is working


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
