### PR TITLE
Add raid evolution info to gym icon

### DIFF
--- a/static/js/map/map.gym.js
+++ b/static/js/map/map.gym.js
@@ -140,6 +140,9 @@ function updateGymMarker(gym, marker, isNotifGym) {
             if (raid.costume != null && raid.costume > 0) {
                 markerImage += '&costume=' + raid.costume
             }
+            if (raid.evolution != null && raid.evolution > 0) {
+                markerImage += '&evolution=' + raid.evolution
+            }
             marker.setZIndexOffset(gymRaidBossZIndex)
         } else { // Upcoming raid.
             markerImage = 'gym_img?team=' + gymTypes[gym.team_id] + '&level=' + gymLevel + '&raid-level=' + raid.level


### PR DESCRIPTION
## Description
Adds the pokemon evolution id to the gym icon.

## Motivation and Context
Currently the icon method supports the evolution id,
but doesn't get the info send to properly use it.

## How Has This Been Tested?

Only tried with my local modified version but should work.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
