### PR TITLE
Quest list: defer render for faster loading

### DIFF
--- a/static/js/quest.js
+++ b/static/js/quest.js
@@ -77,6 +77,7 @@ $(function () {
 
     table = $('#quest-table').DataTable({
         responsive: true,
+        deferRender: true,
         language: {
             url: getDataTablesLocUrl()
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added `deferRender: true` to the quest list.

## Motivation and Context
Avoids loading all stop images by default, which can be hundreds of stops and dozen of megabytes depending on the area.
Only visible quests are loaded (10 by default).

## How Has This Been Tested?
Manually tested on a live instance with about 350 quests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
