### PR TITLE
Performance improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.scss]
+indent_size = 2

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,7 +68,6 @@
     "intersection": "readonly",
     "difference": "readonly",
     "symmetricDifference": "readonly",
-    "lazyLoadImages": "readonly",
     "setCustomTileServers": "readonly",
     "setTileLayer": "readonly",
     "showMotd": "readonly",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,7 +97,7 @@
     "getIvsPercentage": "readonly",
     "getIvsPercentageCssColor": "readonly",
     "getPokemonLevel": "readonly",
-    "setupPokemonMarker": "readonly",
+    "createPokemonMarker": "readonly",
     "searchPokemon": "readonly",
     "gymTypes": "readonly",
     "raidEggImages": "readonly",

--- a/static/js/map/map.gym.js
+++ b/static/js/map/map.gym.js
@@ -1,9 +1,9 @@
 /*
 globals autoPanPopup, $gymNameFilter, addListeners, gymEggZIndex,
-gymNotifiedZIndex, gymRaidBossZIndex, gymSidebar, gymZIndex, mapData, markers,
-markersNoCluster, notifiedGymData, openGymSidebarId:writable, raidIds,
+gymNotifiedZIndex, gymRaidBossZIndex, gymSidebar, gymZIndex, mapData,
+notifiedGymData, openGymSidebarId:writable, raidIds,
 removeMarker, removeRangeCircle, settings, sendNotification, setupRangeCircle,
-upcomingRaidIds, updateRangeCircle
+upcomingRaidIds, updateRangeCircle, updateMarkerLayer
 */
 /* exported processGym, readdGymMarkers, updateGyms */
 
@@ -95,12 +95,7 @@ function isGymRangesActive() {
 }
 
 function setupGymMarker(gym, isNotifGym) {
-    var marker = L.marker([gym.latitude, gym.longitude])
-    if (isNotifGym) {
-        markersNoCluster.addLayer(marker)
-    } else {
-        markers.addLayer(marker)
-    }
+    const marker = L.marker([gym.latitude, gym.longitude])
 
     marker.setBouncingOptions({
         bounceHeight: 20,
@@ -180,21 +175,7 @@ function updateGymMarker(gym, marker, isNotifGym) {
         marker.setZIndexOffset(gymNotifiedZIndex)
     }
 
-    if (isNotifGym && markers.hasLayer(marker)) {
-        // Marker in wrong layer, move to other layer.
-        markers.removeLayer(marker)
-        markersNoCluster.addLayer(marker)
-    } else if (!isNotifGym && markersNoCluster.hasLayer(marker)) {
-        // Marker in wrong layer, move to other layer.
-        markersNoCluster.removeLayer(marker)
-        markers.addLayer(marker)
-    }
-
-    if (settings.bounceNotifMarkers && isNotifGym && !notifiedGymData[gym.gym_id].animationDisabled && !marker.isBouncing()) {
-        marker.bounce()
-    } else if (marker.isBouncing() && (!settings.bounceNotifMarkers || !isNotifGym)) {
-        marker.stopBouncing()
-    }
+    updateMarkerLayer(marker, isNotifGym, notifiedGymData[gym.gym_id])
 
     return marker
 }

--- a/static/js/map/map.gym.js
+++ b/static/js/map/map.gym.js
@@ -130,7 +130,7 @@ function setupGymMarker(gym, isNotifGym) {
 }
 
 function updateGymMarker(gym, marker, isNotifGym) {
-    var markerImage = ''
+    let markerImage = ''
     const upscaleModifier = isNotifGym && settings.upscaleNotifMarkers ? 1.2 : 1
     const gymLevel = getGymLevel(gym)
 
@@ -165,7 +165,7 @@ function updateGymMarker(gym, marker, isNotifGym) {
         markerImage += '&ex-raid-eligible=1'
     }
 
-    var icon = L.icon({
+    const icon = L.contentIcon({
         iconUrl: markerImage,
         iconSize: [48 * upscaleModifier, 48 * upscaleModifier]
     })

--- a/static/js/map/map.js
+++ b/static/js/map/map.js
@@ -1281,7 +1281,6 @@ $(function () {
         if (serverSettings.invasions) {
             initInvasionFilters()
         }
-        lazyLoadImages()
     })
 
     getAllParks()

--- a/static/js/map/map.js
+++ b/static/js/map/map.js
@@ -1,7 +1,7 @@
 /*
 globals getAllParks, getExcludedPokemon, initBackupModals, initInvasionFilters,
 initInvasionFilters, initItemFilters, initPokemonFilters, initSettings,
-initSettingsSidebar, isGymRangesActive, isPokemonRangesActive,
+initSettingsSidebar, initStatsSidebar, isGymRangesActive, isPokemonRangesActive,
 isPokestopRangesActive, isSpawnpointRangesActive, processGym, processNest,
 processPokemon, processPokestop, processScannedLocation, processSpawnpoint,
 processSpawnpoint, processWeather, removePokemon, removeScannedLocation,
@@ -32,7 +32,6 @@ stopFollowingUser, updateRangeCircle
 let $gymNameFilter
 let $pokestopNameFilter
 let settingsSideNav
-let statsSideNav
 let gymSidebar
 let openGymSidebarId
 
@@ -1288,6 +1287,7 @@ $(function () {
     updateMainS2CellId()
 
     $('.modal').modal()
+    $('.tabs').tabs()
 
     if (serverSettings.motd) {
         showMotd(serverSettings.motdTitle, serverSettings.motdText, serverSettings.motdPages, serverSettings.showMotdAlways)
@@ -1299,22 +1299,7 @@ $(function () {
     })
 
     initSettingsSidebar()
-
-    if (serverSettings.statsSidebar) {
-        $('#stats-sidenav').sidenav({
-            edge: 'right',
-            draggable: false,
-            onOpenStart: updateStatsTable
-        })
-        const statsSideNavElem = document.getElementById('stats-sidenav')
-        statsSideNav = M.Sidenav.getInstance(statsSideNavElem)
-        $('.sidenav-trigger[data-target="stats-sidenav"]').on('click', function (e) {
-            if (statsSideNav.isOpen) {
-                statsSideNav.close()
-                e.stopPropagation()
-            }
-        })
-    }
+    initStatsSidebar()
 
     if (serverSettings.gymSidebar) {
         $('#gym-sidebar').sidenav({
@@ -1331,11 +1316,6 @@ $(function () {
         gymSidebar = M.Sidenav.getInstance(gymSidebarElem)
     }
 
-    $('.tabs').tabs()
-    $('#stats-tabs').tabs({
-        onShow: updateStatsTable
-    })
-
     $('#weather-modal').modal({
         onOpenStart: setupWeatherModal
     })
@@ -1343,193 +1323,6 @@ $(function () {
     $('.tooltipped').tooltip()
 
     initBackupModals()
-
-    // Init data tables.
-    if (serverSettings.pokemons) {
-        $('#pokemon-table').DataTable({
-            paging: false,
-            searching: false,
-            info: false,
-            scrollX: true,
-            language: {
-                url: getDataTablesLocUrl()
-            },
-            columnDefs: [
-                { orderable: false, targets: 0 },
-                {
-                    targets: 1,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return `<a href="http://pokemon.gameinfo.io/en/pokemon/${row[1]}" target="_blank" title='${i18n('View on GamePress')}'>#${row[1]}</a>`
-                        }
-                        return row[1]
-                    }
-                },
-                {
-                    targets: 3,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[3].toLocaleString()
-                        }
-                        return row[3]
-                    }
-                },
-                {
-                    targets: 4,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[4].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
-                        }
-                        return row[4]
-                    }
-                }
-            ],
-            order: [[3, 'desc']]
-        })
-    }
-
-    if (serverSettings.gyms) {
-        $('#gym-table').DataTable({
-            paging: false,
-            searching: false,
-            info: false,
-            scrollX: true,
-            language: {
-                url: getDataTablesLocUrl()
-            },
-            columnDefs: [
-                { orderable: false, targets: 0 },
-                {
-                    targets: 2,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[2].toLocaleString()
-                        }
-                        return row[2]
-                    }
-                },
-                {
-                    targets: 3,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[3].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
-                        }
-                        return row[3]
-                    }
-                }
-            ],
-            order: [[2, 'desc']]
-        })
-    }
-
-    if (serverSettings.raids) {
-        $('#egg-table').DataTable({
-            paging: false,
-            searching: false,
-            info: false,
-            scrollX: true,
-            language: {
-                url: getDataTablesLocUrl()
-            },
-            columnDefs: [
-                { orderable: false, targets: 0 },
-                {
-                    targets: 2,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[2].toLocaleString()
-                        }
-                        return row[2]
-                    }
-                },
-                {
-                    targets: 3,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[3].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
-                        }
-                        return row[3]
-                    }
-                }
-            ],
-            order: [[2, 'desc']]
-        })
-
-        $('#raid-pokemon-table').DataTable({
-            paging: false,
-            searching: false,
-            info: false,
-            scrollX: true,
-            language: {
-                url: getDataTablesLocUrl()
-            },
-            columnDefs: [
-                { orderable: false, targets: 0 },
-                {
-                    targets: 2,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return `<a href="http://pokemon.gameinfo.io/en/pokemon/${row[2]}" target="_blank" title='${i18n('View on GamePress')}'>#${row[2]}</a>`
-                        }
-                        return row[2]
-                    }
-                },
-                {
-                    targets: 4,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[4].toLocaleString()
-                        }
-                        return row[4]
-                    }
-                },
-                {
-                    targets: 5,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[5].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
-                        }
-                        return row[5]
-                    }
-                }
-            ],
-            order: [[4, 'desc']]
-        })
-    }
-
-    if (serverSettings.pokestops) {
-        $('#pokestop-table').DataTable({
-            paging: false,
-            searching: false,
-            info: false,
-            scrollX: true,
-            language: {
-                url: getDataTablesLocUrl()
-            },
-            columnDefs: [
-                { orderable: false, targets: 0 },
-                {
-                    targets: 2,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[2].toLocaleString()
-                        }
-                        return row[2]
-                    }
-                },
-                {
-                    targets: 3,
-                    render: function (data, type, row) {
-                        if (type === 'display') {
-                            return row[3].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
-                        }
-                        return row[3]
-                    }
-                }
-            ],
-            order: [[2, 'desc']]
-        })
-    }
 
     window.setInterval(updateMap, serverSettings.mapUpdateInverval)
     window.setInterval(updateLabelDiffTime, 1000)

--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -1,10 +1,11 @@
 /*
 globals addListeners, autoPanPopup, cryFileTypes, isShowAllZoom, mapData,
-markers, markersNoCluster, notifiedPokemonData, pokemonNewSpawnZIndex,
+notifiedPokemonData, pokemonNewSpawnZIndex,
 pokemonNotifiedZIndex, pokemonRareZIndex, pokemonUltraRareZIndex,
 pokemonUncommonZIndex, pokemonVeryRareZIndex, pokemonZIndex, removeMarker,
 removeRangeCircle, sendNotification, settings, setupRangeCircle,
-updateRangeCircle, weatherClassesDay, weatherNames,
+updateRangeCircle, weatherClassesDay, weatherNames, updateMarkerLayer,
+createPokemonMarker
 */
 /* exported processPokemon, updatePokemons */
 
@@ -129,21 +130,7 @@ function updatePokemonMarker(pokemon, marker, isNotifPokemon) {
         marker.setZIndexOffset(pokemonZIndex)
     }
 
-    if (isNotifPokemon && markers.hasLayer(marker)) {
-        // Marker in wrong layer, move to other layer.
-        markers.removeLayer(marker)
-        markersNoCluster.addLayer(marker)
-    } else if (!isNotifPokemon && markersNoCluster.hasLayer(marker)) {
-        // Marker in wrong layer, move to other layer.
-        markersNoCluster.removeLayer(marker)
-        markers.addLayer(marker)
-    }
-
-    if (settings.bounceNotifMarkers && isNotifPokemon && !notifiedPokemonData[pokemon.encounter_id].animationDisabled && !marker.isBouncing()) {
-        marker.bounce()
-    } else if (marker.isBouncing() && (!settings.bounceNotifMarkers || !isNotifPokemon)) {
-        marker.stopBouncing()
-    }
+    updateMarkerLayer(marker, isNotifPokemon, notifiedPokemonData[pokemon.encounter_id])
 
     return marker
 }
@@ -336,12 +323,9 @@ function processPokemon(pokemon) {
             sendPokemonNotification(pokemon)
         }
 
-        if (isNotifPoke) {
-            pokemon.marker = setupPokemonMarker(pokemon, markersNoCluster, serverSettings.generateImages)
-        } else {
-            pokemon.marker = setupPokemonMarker(pokemon, markers, serverSettings.generateImages)
-        }
+        pokemon.marker = createPokemonMarker(pokemon, serverSettings.generateImages)
         customizePokemonMarker(pokemon, pokemon.marker, isNotifPoke)
+
         if (isPokemonRangesActive()) {
             pokemon.rangeCircle = setupRangeCircle(pokemon, 'pokemon', !isNotifPoke)
         }

--- a/static/js/map/map.pokestop.js
+++ b/static/js/map/map.pokestop.js
@@ -95,9 +95,9 @@ function setupPokestopMarker(pokestop, isNotifPokestop) {
 }
 
 function updatePokestopMarker(pokestop, marker, isNotifPokestop) {
-    var shadowImage = null
-    var shadowSize = null
-    var shadowAnchor = null
+    let shadowImage = null
+    let shadowSize = null
+    let shadowAnchor = null
     const upscaleModifier = isNotifPokestop && settings.upscaleNotifMarkers ? 1.3 : 1
 
     if (isPokestopMeetsQuestFilters(pokestop)) {
@@ -122,7 +122,7 @@ function updatePokestopMarker(pokestop, marker, isNotifPokestop) {
         }
     }
 
-    var icon = L.icon({
+    const icon = L.contentIcon({
         iconUrl: getPokestopIconUrlFiltered(pokestop),
         iconSize: [32 * upscaleModifier, 32 * upscaleModifier],
         iconAnchor: [16 * upscaleModifier, 32 * upscaleModifier],

--- a/static/js/map/map.pokestop.js
+++ b/static/js/map/map.pokestop.js
@@ -1,10 +1,10 @@
 /*
 globals $pokestopNameFilter, addListeners, autoPanPopup, getTimeUntil,
-invadedPokestopIds, lpad, luredPokestopIds, lureTypes, mapData, markers,
-markersNoCluster, notifiedPokestopData, pokestopInvasionZIndex,
+invadedPokestopIds, lpad, luredPokestopIds, lureTypes, mapData,
+notifiedPokestopData, pokestopInvasionZIndex,
 pokestopLureZIndex, pokestopNotifiedZIndex, pokestopQuestZIndex,
 pokestopZIndex, removeMarker, removeRangeCircle, sendNotification, settings,
-setupRangeCircle, updateLabelDiffTime, updateRangeCircle
+setupRangeCircle, updateLabelDiffTime, updateRangeCircle, updateMarkerLayer
 */
 /* exported processPokestop */
 
@@ -77,12 +77,7 @@ function isPokestopRangesActive() {
 }
 
 function setupPokestopMarker(pokestop, isNotifPokestop) {
-    var marker = L.marker([pokestop.latitude, pokestop.longitude])
-    if (isNotifPokestop) {
-        markersNoCluster.addLayer(marker)
-    } else {
-        markers.addLayer(marker)
-    }
+    const marker = L.marker([pokestop.latitude, pokestop.longitude])
 
     marker.setBouncingOptions({
         bounceHeight: 20,
@@ -150,21 +145,7 @@ function updatePokestopMarker(pokestop, marker, isNotifPokestop) {
         marker.setZIndexOffset(pokestopZIndex)
     }
 
-    if (isNotifPokestop && markers.hasLayer(marker)) {
-        // Marker in wrong layer, move to other layer.
-        markers.removeLayer(marker)
-        markersNoCluster.addLayer(marker)
-    } else if (!isNotifPokestop && markersNoCluster.hasLayer(marker)) {
-        // Marker in wrong layer, move to other layer.
-        markersNoCluster.removeLayer(marker)
-        markers.addLayer(marker)
-    }
-
-    if (settings.bounceNotifMarkers && isNotifPokestop && !notifiedPokestopData[pokestop.pokestop_id].animationDisabled && !marker.isBouncing()) {
-        marker.bounce()
-    } else if (marker.isBouncing() && (!settings.bounceNotifMarkers || !isNotifPokestop)) {
-        marker.stopBouncing()
-    }
+    updateMarkerLayer(marker, isNotifPokestop, notifiedPokestopData[pokestop.pokestop_id])
 
     return marker
 }

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -1747,24 +1747,38 @@ function initPokemonFilters() {
         inputElement.val(deselectedPokemons.join(',')).trigger('change')
     })
 
-    $('.search').on('input', function () {
-        var searchtext = $(this).val().toString()
-        var parent = $(this)
-        var foundPokemon = []
-        var pokeselectlist = $(this).parent().parent().prev('.pokemon-filter-list').find('.filter-button')
-        if (searchtext === '') {
-            parent.parent().parent().find('.pokemon-select-filtered, .pokemon-deselect-filtered').hide()
-            parent.parent().parent().find('.pokemon-select-all, .pokemon-deselect-all').show()
-            pokeselectlist.show()
-        } else {
-            pokeselectlist.hide()
-            parent.parent().parent().find('.pokemon-select-filtered, .pokemon-deselect-filtered').show()
-            parent.parent().parent().find('.pokemon-select-all, .pokemon-deselect-all').hide()
-            foundPokemon = searchPokemon(searchtext.replace(/\s/g, ''))
-        }
+    const searchInputs = document.querySelectorAll('.search')
+    searchInputs.forEach(function (searchInput) {
+        searchInput.addEventListener('input', function () {
+            const searchText = searchInput.value.replace(/\s/g, '')
+            const footer = searchInput.closest('.filter-footer-container')
+            const filterList = footer.previousElementSibling
+            const filterButtons = filterList.querySelectorAll('.filter-button')
+            const filterContainer = filterList.parentElement
+            filterContainer.style.display = 'none'
 
-        $.each(foundPokemon, function (i, item) {
-            parent.parent().parent().prev('.pokemon-filter-list').find('.filter-button[data-id="' + foundPokemon[i] + '"]').show()
+            let selectAllDisplay
+            let selectFilteredDisplay
+            if (searchText === '') {
+                selectAllDisplay = ''
+                selectFilteredDisplay = 'none'
+                filterButtons.forEach(function (filterButton) {
+                    filterButton.style.display = ''
+                })
+            } else {
+                selectAllDisplay = 'none'
+                selectFilteredDisplay = ''
+                const foundPokemonIds = searchPokemon(searchText)
+                filterButtons.forEach(function (filterButton) {
+                    filterButton.style.display = foundPokemonIds.has(parseInt(filterButton.dataset.id)) ? '' : 'none'
+                })
+            }
+            footer.querySelector('.pokemon-select-all').style.display = selectAllDisplay
+            footer.querySelector('.pokemon-deselect-all').style.display = selectAllDisplay
+            footer.querySelector('.pokemon-select-filtered').style.display = selectFilteredDisplay
+            footer.querySelector('.pokemon-deselect-filtered').style.display = selectFilteredDisplay
+
+            filterContainer.style.display = ''
         })
     })
 

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -150,7 +150,17 @@ function initSettingsSidebar() {
     $('#settings-sidenav').sidenav({
         draggable: false
     })
-    $('.collapsible').collapsible()
+
+    $('.collapsible').collapsible({
+        onOpenStart: function (li) {
+            if ($(li).data('formInitialized')) {
+                return
+            }
+
+            $('select', li).formSelect()
+            $(li).data('formInitialized', true)
+        }
+    })
 
     const settingsSideNavElem = document.getElementById('settings-sidenav')
     settingsSideNav = M.Sidenav.getInstance(settingsSideNavElem)
@@ -1532,22 +1542,31 @@ function initSettingsSidebar() {
         markerStyles = data // eslint-disable-line
         updateStartLocationMarker()
         updateUserLocationMarker()
+
+        const startSelect = document.getElementById('start-location-marker-icon-select')
+        const userSelect = document.getElementById('user-location-marker-icon-select')
+
         $.each(data, function (id, value) {
-            const dataIconStr = value.icon ? `data-icon="${value.icon}"` : ''
-            const option = `<option value="${id}" ${dataIconStr}>${i18n(value.name)}</option>`
-            $('#start-location-marker-icon-select').append(option)
-            $('#user-location-marker-icon-select').append(option)
+            const option = document.createElement('option')
+            option.value = id
+            option.dataset.icon = value.icon ? value.icon : ''
+            option.text = i18n(value.name)
+            startSelect.options.add(option.cloneNode(true))
+            userSelect.options.add(option)
         })
-        $('#start-location-marker-icon-select').val(settings.startLocationMarkerStyle)
-        $('#user-location-marker-icon-select').val(settings.userLocationMarkerStyle)
-        $('#start-location-marker-icon-select').formSelect()
-        $('#user-location-marker-icon-select').formSelect()
+
+        function updateMarkerIconSelect(select, value) {
+            select.value = value
+            if (M.FormSelect.getInstance(select)) {
+                M.FormSelect.init(select)
+            }
+        }
+
+        updateMarkerIconSelect(startSelect, settings.startLocationMarkerStyle)
+        updateMarkerIconSelect(userSelect, settings.userLocationMarkerStyle)
     }).fail(function () {
         console.log('Error loading search marker styles JSON.')
     })
-
-    // Initialize select elements.
-    $('select').formSelect()
 }
 
 const createFilterButton = (function () {

--- a/static/js/map/map.stats.js
+++ b/static/js/map/map.stats.js
@@ -2,11 +2,239 @@
 globals ActiveFortModifierEnum, gymTypes, isGymMeetsGymFilters,
 isGymMeetsRaidFilters, isPokestopMeetsInvasionFilters,
 isPokestopMeetsLureFilters, isPokestopMeetsQuestFilters, map, mapData,
-raidEggImages, settings, statsSideNav
+raidEggImages, settings
 */
-/* exported updateStatsTable */
+/* exported initStatsSidebar, updateStatsTable */
 
+let statsSideNav
 let tabsInstance
+
+function initStatsSidebar() {
+    if (!serverSettings.statsSidebar) {
+        return
+    }
+
+    let tablesInitialized = false
+    const statsSideNavElem = document.getElementById('stats-sidenav')
+    statsSideNav = M.Sidenav.init(statsSideNavElem, {
+        edge: 'right',
+        draggable: false,
+        onOpenStart: function () {
+            if (!tablesInitialized) {
+                initStatsTables()
+                tablesInitialized = true
+            }
+
+            updateStatsTable()
+        }
+    })
+    $('.sidenav-trigger[data-target="stats-sidenav"]').on('click', function (e) {
+        if (statsSideNav.isOpen) {
+            statsSideNav.close()
+            e.stopPropagation()
+        }
+    })
+
+    function initStatsTables() {
+        console.log('initStatsTables')
+
+        $('#stats-tabs').tabs({
+            onShow: updateStatsTable
+        })
+
+        if (serverSettings.pokemons) {
+            $('#pokemon-table').DataTable({
+                paging: false,
+                searching: false,
+                info: false,
+                scrollX: true,
+                language: {
+                    url: getDataTablesLocUrl()
+                },
+                columnDefs: [
+                    {
+                        targets: 0,
+                        orderable: false
+                    },
+                    {
+                        targets: 1,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return `<a href="http://pokemon.gameinfo.io/en/pokemon/${row[1]}" target="_blank" title='${i18n('View on GamePress')}'>#${row[1]}</a>`
+                            }
+                            return row[1]
+                        }
+                    },
+                    {
+                        targets: 3,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[3].toLocaleString()
+                            }
+                            return row[3]
+                        }
+                    },
+                    {
+                        targets: 4,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[4].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
+                            }
+                            return row[4]
+                        }
+                    }
+                ],
+                order: [[3, 'desc']]
+            })
+        }
+
+        if (serverSettings.gyms) {
+            $('#gym-table').DataTable({
+                paging: false,
+                searching: false,
+                info: false,
+                scrollX: true,
+                language: {
+                    url: getDataTablesLocUrl()
+                },
+                columnDefs: [
+                    {
+                        targets: 0,
+                        orderable: false
+                    },
+                    {
+                        targets: 2,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[2].toLocaleString()
+                            }
+                            return row[2]
+                        }
+                    },
+                    {
+                        targets: 3,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[3].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
+                            }
+                            return row[3]
+                        }
+                    }
+                ],
+                order: [[2, 'desc']]
+            })
+        }
+
+        if (serverSettings.raids) {
+            $('#egg-table').DataTable({
+                paging: false,
+                searching: false,
+                info: false,
+                scrollX: true,
+                language: {
+                    url: getDataTablesLocUrl()
+                },
+                columnDefs: [
+                    { orderable: false, targets: 0 },
+                    {
+                        targets: 2,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[2].toLocaleString()
+                            }
+                            return row[2]
+                        }
+                    },
+                    {
+                        targets: 3,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[3].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
+                            }
+                            return row[3]
+                        }
+                    }
+                ],
+                order: [[2, 'desc']]
+            })
+
+            $('#raid-pokemon-table').DataTable({
+                paging: false,
+                searching: false,
+                info: false,
+                scrollX: true,
+                language: {
+                    url: getDataTablesLocUrl()
+                },
+                columnDefs: [
+                    { orderable: false, targets: 0 },
+                    {
+                        targets: 2,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return `<a href="http://pokemon.gameinfo.io/en/pokemon/${row[2]}" target="_blank" title='${i18n('View on GamePress')}'>#${row[2]}</a>`
+                            }
+                            return row[2]
+                        }
+                    },
+                    {
+                        targets: 4,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[4].toLocaleString()
+                            }
+                            return row[4]
+                        }
+                    },
+                    {
+                        targets: 5,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[5].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
+                            }
+                            return row[5]
+                        }
+                    }
+                ],
+                order: [[4, 'desc']]
+            })
+        }
+
+        if (serverSettings.pokestops) {
+            $('#pokestop-table').DataTable({
+                paging: false,
+                searching: false,
+                info: false,
+                scrollX: true,
+                language: {
+                    url: getDataTablesLocUrl()
+                },
+                columnDefs: [
+                    { orderable: false, targets: 0 },
+                    {
+                        targets: 2,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[2].toLocaleString()
+                            }
+                            return row[2]
+                        }
+                    },
+                    {
+                        targets: 3,
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                return row[3].toLocaleString(undefined, { maximumFractionDigits: 1 }) + '%'
+                            }
+                            return row[3]
+                        }
+                    }
+                ],
+                order: [[2, 'desc']]
+            })
+        }
+    }
+}
 
 function updateStatsTable() {
     if (!serverSettings.statsSidebar || !statsSideNav.isOpen) {

--- a/static/js/pokemon-history.js
+++ b/static/js/pokemon-history.js
@@ -234,9 +234,10 @@ function addListeners(marker) {
 function processAppearance(idx, item) {
     const spawnpointId = item.spawnpoint_id
     if (!(spawnpointId in mapData.appearances)) {
-        item.marker = setupPokemonMarker(item, markers, serverSettings.generateImages)
+        item.marker = createPokemonMarker(item, serverSettings.generateImages)
         addListeners(item.marker)
         item.marker.spawnpointId = spawnpointId
+        item.marker.addTo(markers)
         mapData.appearances[spawnpointId] = item
         heatLayer.addLatLng(L.latLng(item.latitude, item.longitude))
     }

--- a/static/js/utils/utils.item.js
+++ b/static/js/utils/utils.item.js
@@ -15,7 +15,8 @@ function initItemData() {
 }
 
 function getItemName(id) {
-    return i18n(itemData[id].name)
+    const item = itemData[id]
+    return typeof item === 'undefined' ? '#' + id : i18n(item.name)
 }
 
 function getItemImageUrl(id) {
@@ -23,9 +24,6 @@ function getItemImageUrl(id) {
 }
 
 function getQuestBundles(id) {
-    if (itemData[id].questBundles) {
-        return itemData[id].questBundles
-    } else {
-        return []
-    }
+    const bundles = itemData[id].questBundles || []
+    return bundles.length === 0 ? [1] : bundles
 }

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -3,7 +3,7 @@ exported canPrimaryInputHover, deviceCanHover, difference, ding,
 disableDarkMode, enableDarkMode, getDecimalSeparator, getParameterByName,
 getPointDistance, getThousandsSeparator, hasCoarsePrimaryPointer,
 hasFinePrimaryPointer, hasLocationSupport, intersection, isMobileDevice,
-isNowBetween, lazyLoadImages, mapServiceProviderNames, removeLastDirsFromUrl,
+isNowBetween, mapServiceProviderNames, removeLastDirsFromUrl,
 showImageModal, symmetricDifference, timestampToDate, timestampToDateTime,
 timestampToTime, toastError, toastInfo, toastSuccess, toastWarning, union,
 updateLabelDiffTime
@@ -347,31 +347,4 @@ function symmetricDifference(setA, setB) {
         }
     }
     return difference
-}
-
-function lazyLoadImages() {
-    const lazyImages = [].slice.call(document.querySelectorAll('img.lazy'))
-
-    if ('IntersectionObserver' in window) {
-        const lazyImageObserver = new IntersectionObserver(function (entries, observer) {
-            entries.forEach(function (entry) {
-                if (entry.isIntersecting) {
-                    const lazyImage = entry.target
-                    lazyImage.src = lazyImage.dataset.src
-                    lazyImage.classList.remove('lazy')
-                    lazyImageObserver.unobserve(lazyImage)
-                }
-            })
-        })
-
-        lazyImages.forEach(function (lazyImage) {
-            lazyImageObserver.observe(lazyImage)
-        })
-    } else {
-        // IntersectionObserver not supported, don't use lazy loading.
-        lazyImages.forEach(function (lazyImage) {
-            lazyImage.src = lazyImage.dataset.src
-            lazyImage.classList.remove('lazy')
-        })
-    }
 }

--- a/static/js/utils/utils.leaflet.js
+++ b/static/js/utils/utils.leaflet.js
@@ -30,3 +30,32 @@ function setTileLayer(layerName, map) {
     map.addLayer(tileLayers[layerName])
     map.tileLayerName = layerName
 }
+
+// An icon that uses <div> instead of <img>, which is measured to has way less performance overhead
+L.ContentIcon = L.Icon.extend({
+
+    createIcon: function (oldIcon) {
+        return this._createDiv('icon', oldIcon)
+    },
+
+    createShadow: function (oldIcon) {
+        return this._createDiv('shadow', oldIcon)
+    },
+
+    _createDiv: function (name, oldIcon) {
+        const src = this._getIconUrl(name)
+        if (!src) {
+            return null
+        }
+
+        const div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div')
+        div.style.content = `url('${src}')`
+        this._setIconStyles(div, name)
+        return div
+    }
+
+})
+
+L.contentIcon = function (options) {
+    return new L.ContentIcon(options)
+}

--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -226,41 +226,46 @@ function createPokemonMarker(pokemon, generateImages) {
     return L.marker([pokemon.latitude, pokemon.longitude], { icon: icon })
 }
 
-function searchPokemon(searchtext) {
-    var searchsplit = searchtext.split(',')
-    var foundPokemon = []
-    var operator = 'add'
-    $.each(searchsplit, function (k, searchstring) {
-        if (searchstring.substring(0, 1) === '+') {
-            searchstring = searchstring.substring(1)
-            operator = 'add'
-        } else if (searchstring.substring(0, 1) === '-') {
-            searchstring = searchstring.substring(1)
-            operator = 'remove'
-        } else {
-            operator = 'add'
+function searchPokemon(searchText) {
+    const searchSplit = searchText.split(',')
+    const foundPokemon = new Set()
+
+    searchSplit.forEach(function (searchString) {
+        let isAdd = true
+        if (searchString.charAt(0) === '+') {
+            searchString = searchString.substring(1)
+        } else if (searchString.charAt(0) === '-') {
+            searchString = searchString.substring(1)
+            isAdd = false
         }
-        if (!isNaN(parseFloat(searchstring)) && !isNaN(searchstring - 0)) {
-            if (operator === 'add') {
-                foundPokemon.push(searchstring)
+
+        if (searchString.length === 0) {
+            return
+        }
+
+        function addDeletePokemon(pokemonId) {
+            if (isAdd) {
+                foundPokemon.add(pokemonId)
             } else {
-                delete foundPokemon[foundPokemon.indexOf(searchstring)]
+                foundPokemon.delete(pokemonId)
             }
-        } else if (searchstring.length > 0 && searchstring !== '-' && searchstring !== '+') {
-            $.each(pokemonSearchList, function (idx, item) {
-                if (item.name.toLowerCase().includes(searchstring.toLowerCase()) ||
-                        item.id.toString() === searchstring.toString() ||
-                        item.type1.toLowerCase().includes(searchstring.toLowerCase()) ||
-                        item.type2.toLowerCase().includes(searchstring.toLowerCase()) ||
-                        item.gen.toString() === searchstring.toLowerCase()) {
-                    if (operator === 'add') {
-                        foundPokemon.push(item.id)
-                    } else {
-                        delete foundPokemon[foundPokemon.indexOf(item.id)]
-                    }
+        }
+
+        const pokemonId = parseInt(searchString)
+        if (!isNaN(pokemonId)) {
+            addDeletePokemon(pokemonId)
+        } else {
+            searchString = searchString.toLowerCase()
+            pokemonSearchList.forEach(function (item) {
+                if (item.name.toLowerCase().includes(searchString) ||
+                        item.type1.toLowerCase().includes(searchString) ||
+                        item.type2.toLowerCase().includes(searchString) ||
+                        item.gen.toString() === searchString) {
+                    addDeletePokemon(item.id)
                 }
             })
         }
     })
+
     return foundPokemon
 }

--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -218,7 +218,7 @@ function getPokemonLevel(cpMultiplier) {
 }
 
 function createPokemonMarker(pokemon, generateImages) {
-    const icon = L.icon({
+    const icon = L.contentIcon({
         iconUrl: getPokemonMapIconUrl(pokemon, generateImages),
         iconSize: [32, 32]
     })

--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -3,7 +3,7 @@ exported genderClasses, getIvsPercentage, getIvsPercentageCssColor,
 getMoveName, getMoveType, getMoveTypeNoI8ln, getPokemonGen, getPokemonIds,
 getPokemonLevel, getPokemonNameWithForm, getPokemonRarity,
 getPokemonRarityName, getPokemonRawIconUrl, getPokemonTypes, initMoveData,
-initPokemonData, searchPokemon, setupPokemonMarker, updatePokemonRarities
+initPokemonData, searchPokemon, createPokemonMarker, updatePokemonRarities
 */
 
 var pokemonData = {}
@@ -217,13 +217,13 @@ function getPokemonLevel(cpMultiplier) {
     return pokemonLevel
 }
 
-function setupPokemonMarker(pokemon, layerGroup, generateImages) {
-    var icon = L.icon({
+function createPokemonMarker(pokemon, generateImages) {
+    const icon = L.icon({
         iconUrl: getPokemonMapIconUrl(pokemon, generateImages),
         iconSize: [32, 32]
     })
 
-    return L.marker([pokemon.latitude, pokemon.longitude], { icon: icon }).addTo(layerGroup)
+    return L.marker([pokemon.latitude, pokemon.longitude], { icon: icon })
 }
 
 function searchPokemon(searchtext) {

--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -90,15 +90,18 @@ function getPokemonIds() {
 }
 
 function getPokemonName(id, evolutionId = 0) {
+    const pokemon = pokemonData[id]
+    const name = typeof pokemon === 'undefined' ? '#' + id : i18n(pokemon.name)
+
     switch (evolutionId) {
         case 1:
-            return i18n('Mega') + ' ' + i18n(pokemonData[id].name)
+            return i18n('Mega') + ' ' + name
         case 2:
-            return i18n('Mega') + ' ' + i18n(pokemonData[id].name) + ' X'
+            return i18n('Mega') + ' ' + name + ' X'
         case 3:
-            return i18n('Mega') + ' ' + i18n(pokemonData[id].name) + ' Y'
+            return i18n('Mega') + ' ' + name + ' Y'
         default:
-            return i18n(pokemonData[id].name)
+            return name
     }
 }
 

--- a/static/sass/components/_modal.scss
+++ b/static/sass/components/_modal.scss
@@ -24,7 +24,7 @@
   max-height: 80% !important;
 
   .modal-content {
-    padding: 0 24px;
+    padding: 0 20px;
 
     h6 {
       padding: 6px 0;
@@ -92,8 +92,7 @@
     align-items: center;
     width: 75px;
     height: 75px;
-    margin-bottom: 8px;
-    margin-right: 8px;
+    margin: 4px;
     float: left;
     line-height: initial;
     color: $text-color;
@@ -117,7 +116,6 @@
   }
 
   .pokemon-filter-list, .quest-item-filter-list, .invasion-filter-list {
-    margin-top: 8px;
     overflow-y: hidden;
   }
 }

--- a/static/sass/components/_modal.scss
+++ b/static/sass/components/_modal.scss
@@ -26,6 +26,11 @@
   .modal-content {
     padding: 0 24px;
 
+    h6 {
+      padding: 6px 0;
+      margin: 0;
+    }
+
     @media screen and (max-width: 600px) {
       padding: 0 12px;
     }
@@ -98,6 +103,13 @@
     &.active {
       background-color: #e0f2f1;
     }
+
+    .filter-image {
+      width: 32px;
+      height: 32px;
+      margin: auto;
+      content: url(../../images/placeholder.png);
+    }
   }
 
   .filter-button-content {
@@ -108,10 +120,10 @@
     margin-top: 8px;
     overflow-y: hidden;
   }
+}
 
-  .pokemon-filter-list {
-    min-height: 80vh;
-  }
+.pokemon-filter-modal, .quest-filter-modal {
+  min-height: 80vh;
 }
 
 .dark .filter-modal {

--- a/templates/map.html
+++ b/templates/map.html
@@ -251,7 +251,7 @@
     {% if settings.quests %}
     <div id="quest-filter-modal" class="modal filter-modal quest-filter-modal">
       <div class="modal-content">
-        <ul id ="quest-filter-tabs" class="tabs quest-filter-tabs">
+        <ul id="quest-filter-tabs" class="tabs quest-filter-tabs">
           <li class="tab"><a href="#quest-pokemon-tab" class="active">Quest Pokémon</a></li>
           <li class="tab"><a href="#quest-item-tab">Quest Items</a></li>
         </ul>
@@ -395,7 +395,7 @@
     {% if settings.quests %}
     <div id="notif-quest-filter-modal" class="modal filter-modal quest-filter-modal">
       <div class="modal-content">
-        <ul id ="notif-quest-filter-tabs" class="tabs quest-filter-tabs">
+        <ul id="notif-quest-filter-tabs" class="tabs quest-filter-tabs">
           <li class="tab"><a href="#notif-quest-pokemon-tab" class="active">Notif Quest Pokémon</a></li>
           <li class="tab"><a href="#notif-quest-item-tab">Notif Quest Items</a></li>
         </ul>


### PR DESCRIPTION
This PR contains several changes to help loading the RocketMAD frontend faster.

## Filters Initialization

1. Filter modals are now lazy loaded. Previously, all 8 Pokémon filter lists were initialized upfront. With more than 650 mons in each list, times the eight lists, times the content of each filter button, this removes more than 80000 DOM nodes (the vast majority of what's in the page). The mons list is now created on demand for each filter button the first time it's clicked. This is clearly the most significant performance gain in the PR.

2. Filter lists (containing each Pokémon) are now created much faster. Previously, a large HTML string was generated containing all buttons, then parsed and added. Now, a template button is parsed only once, then cloned for each mon. While cloning is already faster by itself, avoiding creating a huge HTML chunk piece by piece really lowers the garbage collector work.

3. Filter images are now using a `div` with the CSS `content` property instead of an `<img>` tag. The overall timing for both is similar, but the scripting time is way less with a `div`. For old web compat reasons, `<img>` must load its `src` as soon as possible, whereas `content` downloading and rendering can be scheduled whenever the browser thinks it's most appropriate.

Improvements 2. and 3. may seem a little less relevant now than 1. is done, but I started with those first :)
I've measured than populating a filter list is roughly 2x-3x times faster than before.

## Sidebars

Various sidebar elements are now lazy initialized:
 - `<select>` elements in the left sidebar are `materialize`'d only when their collapsible section is first expanded.
 - `<table>` elements in the right stats sidebar are `DataTable`'d only when the stats bar is first shown.
 
## Markers

1. The gym/stop marker icon is now set directly before being added to the map, which avoids a double layout pass for each marker and removes the jarring switch from the default blue marker to the gym/stop one.

2. The marker clustering plugin was refreshing its internal state for every added marker. Now, it's only refreshed once after every mon/stop/gym has been processed.

3. Like filter images, mons/stops/gyms markers are now a `<div>` with a CSS `content` property. See 3. in the filters paragraph for the rationale.

## Search

Searching in Pokémon filters is now much faster (I've measured about a 5-6x speedup, typing is now perfectly smooth for me on an older phone when it was lagging before):

1. The buttons container is hidden, then buttons are shown/hidden depending on the search terms, then the container is displayed again. This allows for a single layout recalculation instead of several.

2. The algorithm complexity to find/show/hide the matching filter buttons is down from `O(m × n)` to `O(n)` (with `m` the number of mons matching the search criteria and `n` the total number of mons).

## Other minor improvements

- Introduced variables to avoid looking up the same DOM elements several times.
- Used native built-in DOM functions instead of jQuery in code I had to modify.
- All stats sidebar functions have been moved from `map.js` to `map.stats.js`.
- Marker layer change (clustered to non-clustered or vice versa) and bouncing has been extracted into a single function.
- Minor filter modal layout changes (keeps the header always the same size and avoids a large right margin).

## Results

On a decent PC, the map loads roughly 1.5x (thousands of markers) to 3x faster (empty map) for me than before, depending on the number of markers and other conditions (no scientific benchmark, just numbers from profiling sessions using Chrome DevTools).

These are my numbers for loading a map with ~1600 non clustered markers displayed, before and after (same location, same settings):
![before](https://user-images.githubusercontent.com/1623034/95400519-11089f00-090b-11eb-83dc-52adea6ddfdd.png) ![after](https://user-images.githubusercontent.com/1623034/95400533-182fad00-090b-11eb-8ef6-bcc282c6fcc6.png)


On mobile, which was the main motivation behind this PR, the page not only loads faster, but the freezes after loading (unresponsive input) that could be observable for several seconds on older mobile devices are completely gone in my case.
