### PR TITLE
Refactored filters using FilterManager

### DIFF
--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -5,7 +5,7 @@ pokemonNotifiedZIndex, pokemonRareZIndex, pokemonUltraRareZIndex,
 pokemonUncommonZIndex, pokemonVeryRareZIndex, pokemonZIndex, removeMarker,
 removeRangeCircle, sendNotification, settings, setupRangeCircle,
 updateRangeCircle, weatherClassesDay, weatherNames, updateMarkerLayer,
-createPokemonMarker
+createPokemonMarker, filterManagers
 */
 /* exported processPokemon, updatePokemons */
 
@@ -291,7 +291,7 @@ function pokemonLabel(item) {
               <div>
                 <a href='javascript:togglePokemonNotif(${id})' class='link-button' title="${notifText}"><i class="${notifIconClass}"></i></a>
                 <a href='javascript:excludePokemon(${id})' class='link-button' title=${i18n('Hide')}><i class="fas fa-eye-slash"></i></a>
-                <a href='javascript:removePokemonMarker("${encounterId}")' class='link-button' title='Remove'><i class="fas fa-trash"></i></a>
+                <a href='javascript:removePokemonMarker("${encounterId}")' class='link-button' title='${i18n('Remove')}><i class="fas fa-trash"></i></a>
                 <a href='https://pokemongo.gamepress.gg/pokemon/${id}' class='link-button' target='_blank' title='${i18n('View on GamePress')}'><i class="fas fa-info-circle"></i></a>
               </div>
             </div>
@@ -453,13 +453,15 @@ function getExcludedPokemon() {
 }
 
 function excludePokemon(id) { // eslint-disable-line no-unused-vars
-    if (!settings.excludedPokemon.has(id)) {
-        $('label[for="exclude-pokemon"] .pokemon-filter-list .filter-button[data-id="' + id + '"]').click()
+    if (filterManagers.excludedPokemon !== null) {
+        filterManagers.excludedPokemon.add([id])
     }
 }
 
 function togglePokemonNotif(id) { // eslint-disable-line no-unused-vars
-    $('label[for="no-notif-pokemon"] .pokemon-filter-list .filter-button[data-id="' + id + '"]').click()
+    if (filterManagers.notifPokemon !== null) {
+        filterManagers.notifPokemon.toggle(id)
+    }
 }
 
 function isNotifPokemon(pokemon) {

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -1592,7 +1592,7 @@ const createFilterButton = (function () {
         }
 
         return new IntersectionObserver(function (entries, observer) {
-            entries.forEach(function (entry) {
+            entries.forEach(entry => {
                 if (entry.isIntersecting) {
                     const lazyImage = entry.target
                     lazyImage.style.content = lazyImage.dataset.lazyContent
@@ -1644,691 +1644,352 @@ function setModalFunction(modalDiv, optionName, fn) {
     const modal = M.Modal.getInstance(modalDiv) || M.Modal.init(modalDiv)
     const existingOption = modal.options[optionName]
     modal.options[optionName] = typeof existingOption === 'function'
-        ? function () {
+        ? () => {
             existingOption()
             fn()
         }
         : fn
 }
 
-function initPokemonFilters() {
-    const pokemonIds = getPokemonIds()
+class FilterManager {
+    constructor(modalId, settingsKey, title, isExclusion, onAdded, onRemoved) {
+        this._settingsKey = settingsKey
+        this._title = title
+        this.isExclusion = isExclusion
+        this._onAdded = onAdded
+        this._onRemoved = onRemoved
 
-    function fillPokemonFilterList(filterList, settingsPokemonIds, isExclusion) {
-        if (filterList.hasChildNodes()) {
-            return
-        }
-
-        for (const id of pokemonIds) {
-            const isActive = settingsPokemonIds.has(id) !== isExclusion
-            filterList.appendChild(createFilterButton(
-                id,
-                '#' + id,
-                getPokemonName(id),
-                getPokemonRawIconUrl({ pokemon_id: id }, serverSettings.generateImages),
-                isActive
-            ))
-        }
-    }
-
-    function configurePokemonModal(modalId, settingsPokemonId, isExclusion) {
         const modalDiv = document.getElementById(modalId)
+        this._settingsIds = settings[settingsKey]
+        this._titleElement = modalDiv.querySelector(this.getTitleSelector())
+        this._buttonById = { }
+        this._modalInitialized = false
 
-        setModalFunction(modalDiv, 'onOpenStart', function () {
-            fillPokemonFilterList(modalDiv.querySelector('.pokemon-filter-list'), settingsPokemonId, isExclusion)
+        setModalFunction(modalDiv, 'onOpenStart', () => {
+            if (this._modalInitialized) {
+                return
+            }
+
+            const filterListDiv = modalDiv.querySelector(this.getListSelector())
+
+            for (const id of this.getAllIds()) {
+                const isActive = this._settingsIds.has(id) !== isExclusion
+                const button = createFilterButton(
+                    id,
+                    this.getButtonHeader(id),
+                    this.getButtonFooter(id),
+                    this.getButtonIconUrl(id),
+                    isActive
+                )
+                this._buttonById[id] = button
+                filterListDiv.appendChild(button)
+            }
+
+            this._updateTitle()
+
+            filterListDiv.addEventListener('click', e => {
+                const button = e.target.closest('.filter-button')
+                if (button === null) {
+                    return
+                }
+
+                const id = this.idFromString(button.dataset.id)
+                if (button.classList.contains('active') === isExclusion) {
+                    this.add([id])
+                } else {
+                    this.remove([id])
+                }
+            })
+
+            function onSelectDeselectAllClick(isSelect, e) {
+                e.preventDefault()
+
+                const visibleIds = []
+                for (const idString in this._buttonById) {
+                    const button = this._buttonById[idString]
+                    if (button.style.display !== 'none' && button.classList.contains('active') !== isSelect) {
+                        visibleIds.push(this.idFromString(idString))
+                    }
+                }
+
+                if (isExclusion === isSelect) {
+                    this.remove(visibleIds)
+                } else {
+                    this.add(visibleIds)
+                }
+            }
+
+            filterListDiv.parentElement.querySelector('.filter-select-all').addEventListener('click', onSelectDeselectAllClick.bind(this, true))
+            filterListDiv.parentElement.querySelector('.filter-deselect-all').addEventListener('click', onSelectDeselectAllClick.bind(this, false))
+
+            this._modalInitialized = true
         })
     }
 
-    configurePokemonModal('pokemon-filter-modal', settings.excludedPokemon, true)
-    configurePokemonModal('pokemon-values-filter-modal', settings.noFilterValuesPokemon, true)
-    configurePokemonModal('raid-pokemon-filter-modal', settings.excludedRaidPokemon, true)
-    configurePokemonModal('quest-filter-modal', settings.excludedQuestPokemon, true)
-    configurePokemonModal('notif-pokemon-filter-modal', settings.notifPokemon, false)
-    configurePokemonModal('notif-pokemon-values-filter-modal', settings.notifValuesPokemon, false)
-    configurePokemonModal('notif-raid-pokemon-filter-modal', settings.notifRaidPokemon, false)
-    configurePokemonModal('notif-quest-filter-modal', settings.notifQuestPokemon, false)
+    getListSelector() { throw Error('Not implemented') }
+    getTitleSelector() { throw Error('Not implemented') }
+    getAllIds() { throw Error('Not implemented') }
+    getButtonHeader() { throw Error('Not implemented') }
+    getButtonFooter() { throw Error('Not implemented') }
+    getButtonIconUrl() { throw Error('Not implemented') }
+    idFromString() { throw Error('Not implemented') }
 
-    $('.pokemon-filter-list').on('click', '.filter-button', function () {
-        var img = $(this)
-        var inputElement = $(this).parent().parent().find('input[id$=pokemon]')
-        var value = inputElement.val().length > 0 ? inputElement.val().split(',') : []
-        var id = img.data('id').toString()
-        if (img.hasClass('active')) {
-            inputElement.val((value.concat(id).join(','))).trigger('change')
-            img.removeClass('active')
-        } else {
-            inputElement.val(value.filter(function (elem) {
-                return elem !== id
-            }).join(',')).trigger('change')
-            img.addClass('active')
+    _toggleButtonActive(pokemonId, isActive) {
+        if (this._modalInitialized) {
+            const button = this._buttonById[pokemonId]
+            if (button) {
+                button.classList.toggle('active', isActive)
+            }
         }
-    })
+    }
 
-    $('.pokemon-select-all').on('click', function (e) {
-        e.preventDefault()
-        var parent = $(this).parent().parent().parent()
-        parent.find('.pokemon-filter-list .filter-button:visible').addClass('active')
-        parent.find('input[id$=pokemon]').val('').trigger('change')
-    })
+    _updateTitle() {
+        const activeCount = this.isExclusion ? this.getAllIds().size - this._settingsIds.size : this._settingsIds.size
+        const countDisplay = activeCount === this.getAllIds().size ? i18n('All') : activeCount.toString()
+        this._titleElement.textContent = `${this._title} (${countDisplay})`
+    }
 
-    $('.pokemon-deselect-all').on('click', function (e) {
-        e.preventDefault()
-        var parent = $(this).parent().parent().parent()
-        parent.find('.pokemon-filter-list .filter-button:visible').removeClass('active')
-        parent.find('input[id$=pokemon]').val(Array.from(pokemonIds).join(',')).trigger('change')
-    })
+    add(ids) {
+        for (const id of ids) {
+            this._settingsIds.add(id)
+            this._toggleButtonActive(id, !this.isExclusion)
+        }
 
-    $('.pokemon-select-filtered').on('click', function (e) {
-        e.preventDefault()
-        var parent = $(this).parent().parent().parent()
-        var inputElement = parent.find('input[id$=pokemon]')
-        var deselectedPokemons = inputElement.val().length > 0 ? inputElement.val().split(',') : []
-        var visibleNotActiveIconElements = parent.find('.filter-button:visible:not(.active)')
-        visibleNotActiveIconElements.addClass('active')
-        $.each(visibleNotActiveIconElements, function (i, item) {
-            var id = $(this).data('id').toString()
-            deselectedPokemons = deselectedPokemons.filter(function (item) {
-                return item !== id
-            })
-        })
-        inputElement.val(deselectedPokemons.join(',')).trigger('change')
-    })
+        this._updateTitle()
+        this._onAdded(ids)
+        Store.set(this._settingsKey, this._settingsIds)
+    }
 
-    $('.pokemon-deselect-filtered').on('click', function (e) {
-        e.preventDefault()
-        var parent = $(this).parent().parent().parent()
-        var inputElement = parent.find('input[id$=pokemon]')
-        var deselectedPokemons = inputElement.val().length > 0 ? inputElement.val().split(',') : []
-        var visibleActiveIconElements = parent.find('.filter-button:visible.active')
-        visibleActiveIconElements.removeClass('active')
-        $.each(visibleActiveIconElements, function (i, item) {
-            deselectedPokemons.push($(this).data('id'))
-        })
-        inputElement.val(deselectedPokemons.join(',')).trigger('change')
-    })
+    remove(ids) {
+        for (const id of ids) {
+            this._settingsIds.delete(id)
+            this._toggleButtonActive(id, this.isExclusion)
+        }
+
+        this._updateTitle()
+        this._onRemoved(ids)
+        Store.set(this._settingsKey, this._settingsIds)
+    }
+
+    clear() {
+        this.remove(this._settingsIds)
+    }
+
+    toggle(id) {
+        if (this._settingsIds.has(id)) {
+            this.remove([id])
+        } else {
+            this.add([id])
+        }
+    }
+}
+
+const filterManagers = {
+    excludedPokemon: null,
+    notifPokemon: null,
+    noFilterValuesPokemon: null,
+    notifValuesPokemon: null,
+    excludedRaidPokemon: null,
+    notifRaidPokemon: null,
+    excludedQuestPokemon: null,
+    notifQuestPokemon: null,
+    excludedQuestItems: null,
+    notifQuestItems: null,
+    excludedInvasions: null,
+    notifInvasions: null
+}
+
+function initPokemonFilters() {
+    const allPokemonIds = getPokemonIds()
+
+    class PokemonFilterManager extends FilterManager {
+        getListSelector() { return '.pokemon-filter-list' }
+        getTitleSelector() { return '.pokemon-filter-title' }
+        getAllIds() { return allPokemonIds }
+        getButtonHeader(id) { return '#' + id }
+        getButtonFooter(id) { return getPokemonName(id) }
+        getButtonIconUrl(id) { return getPokemonRawIconUrl({ pokemon_id: id }, serverSettings.generateImages) }
+        idFromString(idString) { return parseInt(idString) }
+    }
 
     const searchInputs = document.querySelectorAll('.search')
     searchInputs.forEach(function (searchInput) {
-        searchInput.addEventListener('input', function () {
+        searchInput.addEventListener('input', () => {
             const searchText = searchInput.value.replace(/\s/g, '')
             const footer = searchInput.closest('.filter-footer-container')
             const filterList = footer.previousElementSibling
             const filterButtons = filterList.querySelectorAll('.filter-button')
             const filterContainer = filterList.parentElement
+            const oldContainerDisplay = filterContainer.style.display
             filterContainer.style.display = 'none'
 
-            let selectAllDisplay
-            let selectFilteredDisplay
             if (searchText === '') {
-                selectAllDisplay = ''
-                selectFilteredDisplay = 'none'
                 filterButtons.forEach(function (filterButton) {
                     filterButton.style.display = ''
                 })
             } else {
-                selectAllDisplay = 'none'
-                selectFilteredDisplay = ''
                 const foundPokemonIds = searchPokemon(searchText)
                 filterButtons.forEach(function (filterButton) {
                     filterButton.style.display = foundPokemonIds.has(parseInt(filterButton.dataset.id)) ? '' : 'none'
                 })
             }
-            footer.querySelector('.pokemon-select-all').style.display = selectAllDisplay
-            footer.querySelector('.pokemon-deselect-all').style.display = selectAllDisplay
-            footer.querySelector('.pokemon-select-filtered').style.display = selectFilteredDisplay
-            footer.querySelector('.pokemon-deselect-filtered').style.display = selectFilteredDisplay
 
-            filterContainer.style.display = ''
+            filterContainer.style.display = oldContainerDisplay
         })
     })
 
     if (serverSettings.pokemons) {
-        $('#exclude-pokemon').val(Array.from(settings.excludedPokemon))
-        if (settings.excludedPokemon.size === 0) {
-            $('#filter-pokemon-title').text(`${i18n('Pokémon')} (${i18n('All')})`)
-        } else {
-            $('#filter-pokemon-title').text(`${i18n('Pokémon')} (${pokemonIds.size - settings.excludedPokemon.size})`)
-        }
-
-        $('label[for="exclude-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (!settings.excludedPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#exclude-pokemon').on('change', function (e) {
-            const prevExcludedPokemon = settings.excludedPokemon
-            settings.excludedPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-
-            const newExcludedPokemon = difference(settings.excludedPokemon, prevExcludedPokemon)
-            if (newExcludedPokemon.size > 0) {
-                updatePokemons(newExcludedPokemon)
-            }
-
-            const newReincludedPokemon = difference(prevExcludedPokemon, settings.excludedPokemon)
-            reincludedPokemon = union(reincludedPokemon, newReincludedPokemon)
-            if (reincludedPokemon.size > 0) {
+        filterManagers.excludedPokemon = new PokemonFilterManager(
+            'pokemon-filter-modal', 'excludedPokemon', i18n('Pokémon'), true,
+            pokemonIds => updatePokemons(new Set(pokemonIds)),
+            pokemonIds => {
+                for (const pokemonId of pokemonIds) {
+                    reincludedPokemon.add(pokemonId)
+                }
                 updateMap()
             }
+        )
 
-            if (settings.excludedPokemon.size === 0) {
-                $('#filter-pokemon-title').text(`${i18n('Pokémon')} (${i18n('All')})`)
-            } else {
-                $('#filter-pokemon-title').text(`${i18n('Pokémon')} (${pokemonIds.size - settings.excludedPokemon.size})`)
-            }
-
-            Store.set('excludedPokemon', settings.excludedPokemon)
-        })
+        filterManagers.notifPokemon = new PokemonFilterManager(
+            'notif-pokemon-filter-modal', 'notifPokemon', i18n('Notif Pokémon'), false,
+            pokemonIds => {
+                updatePokemons(new Set(pokemonIds))
+                if (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways) {
+                    updateMap({ loadAllPokemon: true })
+                }
+            },
+            pokemonIds => updatePokemons(new Set(pokemonIds))
+        )
     }
 
     if (serverSettings.pokemonValues) {
-        $('#unfiltered-pokemon').val(Array.from(settings.noFilterValuesPokemon))
-        if (settings.noFilterValuesPokemon.size === 0) {
-            $('#filter-values-pokemon-title').text(`${i18n('Pokémon filtered by values')} (${i18n('All')})`)
-        } else {
-            $('#filter-values-pokemon-title').text(`${i18n('Pokémon filtered by values')} (${pokemonIds.size - settings.noFilterValuesPokemon.size})`)
-        }
-
-        $('label[for="unfiltered-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (!settings.noFilterValuesPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#unfiltered-pokemon').on('change', function (e) {
-            const prevNoFilterValuesPokemon = settings.noFilterValuesPokemon
-            settings.noFilterValuesPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-
-            const newFilterValuesPokemon = difference(prevNoFilterValuesPokemon, settings.noFilterValuesPokemon)
-            if (newFilterValuesPokemon.size > 0) {
-                updatePokemons(newFilterValuesPokemon)
-            }
-
-            const newNoFilterValuesPokemon = difference(settings.noFilterValuesPokemon, prevNoFilterValuesPokemon)
-            reincludedPokemon = union(reincludedPokemon, newNoFilterValuesPokemon)
-            if (reincludedPokemon.size > 0) {
+        filterManagers.noFilterValuesPokemon = new PokemonFilterManager(
+            'pokemon-values-filter-modal', 'noFilterValuesPokemon', i18n('Pokémon filtered by values'), true,
+            pokemonIds => {
+                for (const pokemonId of pokemonIds) {
+                    reincludedPokemon.add(pokemonId)
+                }
                 updateMap()
-            }
+            },
+            pokemonIds => updatePokemons(new Set(pokemonIds))
+        )
 
-            if (settings.noFilterValuesPokemon.size === 0) {
-                $('#filter-values-pokemon-title').text(`${i18n('Pokémon filtered by values')} (${i18n('All')})`)
-            } else {
-                $('#filter-values-pokemon-title').text(`${i18n('Pokémon filtered by values')} (${pokemonIds.size - settings.noFilterValuesPokemon.size})`)
-            }
-
-            Store.set('noFilterValuesPokemon', settings.noFilterValuesPokemon)
-        })
+        filterManagers.notifValuesPokemon = new PokemonFilterManager(
+            'notif-pokemon-values-filter-modal', 'notifValuesPokemon', i18n('Notif Pokémon filtered by values'), false,
+            pokemonIds => {
+                updatePokemons(new Set(pokemonIds))
+                if (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways) {
+                    updateMap({ loadAllPokemon: true })
+                }
+            },
+            pokemonIds => updatePokemons(new Set(pokemonIds))
+        )
     }
 
     if (serverSettings.raidFilters) {
-        $('#exclude-raid-pokemon').val(Array.from(settings.excludedRaidPokemon))
-        if (settings.excludedRaidPokemon.size === 0) {
-            $('#filter-raid-pokemon-title').text(`${i18n('Raid Bosses')} (${i18n('All')})`)
-        } else {
-            $('#filter-raid-pokemon-title').text(`${i18n('Raid Bosses')} (${pokemonIds.size - settings.excludedRaidPokemon.size})`)
-        }
-
-        $('label[for="exclude-raid-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (!settings.excludedRaidPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#exclude-raid-pokemon').on('change', function (e) {
-            const prevExcludedPokemon = settings.excludedRaidPokemon
-            settings.excludedRaidPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-
-            const newExcludedPokemon = difference(settings.excludedRaidPokemon, prevExcludedPokemon)
-            if (newExcludedPokemon.size > 0 || settings.showGyms) {
+        filterManagers.excludedRaidPokemon = new PokemonFilterManager(
+            'raid-pokemon-filter-modal', 'excludedRaidPokemon', i18n('Raid Bosses'), true,
+            () => updateGyms(),
+            () => {
                 updateGyms()
-            }
-
-            const newIncludedPokemon = difference(prevExcludedPokemon, settings.excludedRaidPokemon)
-            if (newIncludedPokemon.size > 0) {
                 updateMap({ loadAllGyms: true })
             }
+        )
 
-            if (settings.excludedRaidPokemon.size === 0) {
-                $('#filter-raid-pokemon-title').text(`${i18n('Raid Bosses')} (${i18n('All')})`)
-            } else {
-                $('#filter-raid-pokemon-title').text(`${i18n('Raid Bosses')} (${pokemonIds.size - settings.excludedRaidPokemon.size})`)
-            }
-
-            Store.set('excludedRaidPokemon', settings.excludedRaidPokemon)
-        })
+        filterManagers.notifRaidPokemon = new PokemonFilterManager(
+            'notif-raid-pokemon-filter-modal', 'notifRaidPokemon', i18n('Notif Raid Bosses'), false,
+            () => updateGyms(),
+            () => updateGyms()
+        )
     }
 
     if (serverSettings.quests) {
-        $('#exclude-quest-pokemon').val(Array.from(settings.excludedQuestPokemon))
-        if (settings.excludedQuestPokemon.size === 0) {
-            $('a[href="#quest-pokemon-tab"]').text(`${i18n('Quest Pokémon')} (${i18n('All')})`)
-        } else {
-            $('a[href="#quest-pokemon-tab"]').text(`${i18n('Quest Pokémon')} (${pokemonIds.size - settings.excludedQuestPokemon.size})`)
-        }
-
-        $('label[for="exclude-quest-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (!settings.excludedQuestPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#exclude-quest-pokemon').on('change', function (e) {
-            const prevExcludedPokemon = settings.excludedQuestPokemon
-            settings.excludedQuestPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-
-            const newExcludedPokemon = difference(settings.excludedQuestPokemon, prevExcludedPokemon)
-            if (newExcludedPokemon.size > 0) {
+        filterManagers.excludedQuestPokemon = new PokemonFilterManager(
+            'quest-filter-modal', 'excludedQuestPokemon', i18n('Quest Pokémon'), true,
+            () => updatePokestops(),
+            () => {
                 updatePokestops()
-            }
-
-            const newIncludedPokemon = difference(prevExcludedPokemon, settings.excludedQuestPokemon)
-            if (newIncludedPokemon.size > 0) {
                 updateMap({ loadAllPokestops: true })
             }
+        )
 
-            if (settings.excludedQuestPokemon.size === 0) {
-                $('a[href="#quest-pokemon-tab"]').text(`${i18n('Quest Pokémon')} (${i18n('All')})`)
-            } else {
-                $('a[href="#quest-pokemon-tab"]').text(`${i18n('Quest Pokémon')} (${pokemonIds.size - settings.excludedQuestPokemon.size})`)
-            }
-            $('#quest-filter-tabs').tabs('updateTabIndicator')
-
-            Store.set('excludedQuestPokemon', settings.excludedQuestPokemon)
-        })
-    }
-
-    if (serverSettings.pokemons) {
-        const noNotifPoke = difference(pokemonIds, settings.notifPokemon)
-        $('#no-notif-pokemon').val(Array.from(noNotifPoke))
-        if (settings.notifPokemon.size === pokemonIds.size) {
-            $('#notif-pokemon-filter-title').text(`${i18n('Notif Pokémon')} (${i18n('All')})`)
-        } else {
-            $('#notif-pokemon-filter-title').text(`${i18n('Notif Pokémon')} (${settings.notifPokemon.size})`)
-        }
-
-        $('label[for="no-notif-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (settings.notifPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#no-notif-pokemon').on('change', function (e) {
-            const prevNotifPokemon = settings.notifPokemon
-            const noNotifPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-            settings.notifPokemon = difference(pokemonIds, noNotifPokemon)
-
-            const newNotifPokemon = difference(settings.notifPokemon, prevNotifPokemon)
-            const newNoNotifPokemon = intersection(noNotifPokemon, prevNotifPokemon)
-
-            updatePokemons(union(newNotifPokemon, newNoNotifPokemon))
-
-            if (newNotifPokemon.size > 0 && (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
-                updateMap({ loadAllPokemon: true })
-            }
-
-            if (settings.notifPokemon.size === pokemonIds.size) {
-                $('#notif-pokemon-filter-title').text(`${i18n('Notif Pokémon')} (${i18n('All')})`)
-            } else {
-                $('#notif-pokemon-filter-title').text(`${i18n('Notif Pokémon')} (${settings.notifPokemon.size})`)
-            }
-
-            Store.set('notifPokemon', settings.notifPokemon)
-        })
-    }
-
-    if (serverSettings.pokemonValues) {
-        const noNotifPoke = difference(pokemonIds, settings.notifValuesPokemon)
-        $('#no-notif-values-pokemon').val(Array.from(noNotifPoke))
-        if (settings.notifValuesPokemon.size === pokemonIds.size) {
-            $('#notif-pokemon-values-filter-title').text(`${i18n('Notif Pokémon filtered by values')} (${i18n('All')})`)
-        } else {
-            $('#notif-pokemon-values-filter-title').text(`${i18n('Notif Pokémon filtered by values')} (${settings.notifValuesPokemon.size})`)
-        }
-
-        $('label[for="no-notif-values-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (settings.notifValuesPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#no-notif-values-pokemon').on('change', function (e) {
-            const oldValues = settings.notifValuesPokemon
-            const noNotifPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-            settings.notifValuesPokemon = difference(pokemonIds, noNotifPokemon)
-
-            const newValues = difference(settings.notifValuesPokemon, oldValues)
-            const removedValues = intersection(oldValues, settings.notifValuesPokemon)
-
-            updatePokemons(union(newValues, removedValues))
-
-            if (newValues.size > 0 && (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
-                updateMap({ loadAllPokemon: true })
-            }
-
-            if (settings.notifValuesPokemon.size === pokemonIds.size) {
-                $('#notif-pokemon-values-filter-title').text(`${i18n('Notif Pokémon filtered by values')} (${i18n('All')})`)
-            } else {
-                $('#notif-pokemon-values-filter-title').text(`${i18n('Notif Pokémon filtered by values')} (${settings.notifValuesPokemon.size})`)
-            }
-
-            Store.set('notifValuesPokemon', settings.notifValuesPokemon)
-        })
-    }
-
-    if (serverSettings.raids) {
-        const noNotifPoke = difference(pokemonIds, settings.notifRaidPokemon)
-        $('#no-notif-raid-pokemon').val(Array.from(noNotifPoke))
-        if (settings.notifRaidPokemon.size === pokemonIds.size) {
-            $('#notif-raid-pokemon-filter-title').text(`${i18n('Notif Raid Bosses')} (${i18n('All')})`)
-        } else {
-            $('#notif-raid-pokemon-filter-title').text(`${i18n('Notif Raid Bosses')} (${settings.notifRaidPokemon.size})`)
-        }
-
-        $('label[for="no-notif-raid-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (settings.notifRaidPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#no-notif-raid-pokemon').on('change', function (e) {
-            const noNotifPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-            settings.notifRaidPokemon = difference(pokemonIds, noNotifPokemon)
-
-            updateGyms()
-
-            if (settings.notifRaidPokemon.size === pokemonIds.size) {
-                $('#notif-raid-pokemon-filter-title').text(`${i18n('Notif Raid Bosses')} (${i18n('All')})`)
-            } else {
-                $('#notif-raid-pokemon-filter-title').text(`${i18n('Notif Raid Bosses')} (${settings.notifRaidPokemon.size})`)
-            }
-
-            Store.set('notifRaidPokemon', settings.notifRaidPokemon)
-        })
-    }
-
-    if (serverSettings.quests) {
-        const noNotifPoke = difference(pokemonIds, settings.notifQuestPokemon)
-        $('#no-notif-quest-pokemon').val(Array.from(noNotifPoke))
-        if (settings.notifQuestPokemon.size === pokemonIds.size) {
-            $('a[href="#notif-quest-pokemon-tab"]').text(`${i18n('Notif Quest Pokémon')} (${i18n('All')})`)
-        } else {
-            $('a[href="#notif-quest-pokemon-tab"]').text(`${i18n('Notif Quest Pokémon')} (${settings.notifQuestPokemon.size})`)
-        }
-
-        $('label[for="no-notif-quest-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-            if (settings.notifQuestPokemon.has($(this).data('id'))) {
-                $(this).addClass('active')
-            }
-        })
-
-        $('#no-notif-quest-pokemon').on('change', function (e) {
-            const noNotifPokemon = $(this).val().length > 0 ? new Set($(this).val().split(',').map(Number)) : new Set()
-            settings.notifQuestPokemon = difference(pokemonIds, noNotifPokemon)
-
-            updatePokestops()
-
-            if (settings.notifQuestPokemon.size === pokemonIds.size) {
-                $('a[href="#notif-quest-pokemon-tab"]').text(`${i18n('Notif Quest Pokémon')} (${i18n('All')})`)
-            } else {
-                $('a[href="#notif-quest-pokemon-tab"]').text(`${i18n('Notif Quest Pokémon')} (${settings.notifQuestPokemon.size})`)
-            }
-            $('#notif-quest-filter-tabs').tabs('updateTabIndicator')
-
-            Store.set('notifQuestPokemon', settings.notifQuestPokemon)
-        })
+        filterManagers.notifQuestPokemon = new PokemonFilterManager(
+            'notif-quest-filter-modal', 'notifQuestPokemon', i18n('Notif Quest Pokémon'), false,
+            () => updatePokestops(),
+            () => updatePokestops()
+        )
     }
 }
 
 function initItemFilters() {
-    document.querySelectorAll('.quest-filter-modal').forEach(function (modalDiv) {
-        setModalFunction(modalDiv, 'onOpenEnd', function () {
+    document.querySelectorAll('.quest-filter-modal').forEach(modalDiv => {
+        setModalFunction(modalDiv, 'onOpenEnd', () => {
             M.Tabs.getInstance(modalDiv.querySelector('.quest-filter-tabs')).updateTabIndicator()
         })
     })
 
-    const questItemIds = []
+    const questItemIds = new Set()
     const includeInFilter = [6, 1, 2, 3, 701, 703, 705, 706, 708, 709, 101, 102, 103, 104, 201, 202, 1301, 1201, 1202, 501, 502, 503, 504, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 7]
 
     for (const id of includeInFilter) {
         for (const bundle of getQuestBundles(id)) {
-            questItemIds.push(id + '_' + bundle)
+            questItemIds.add(id + '_' + bundle)
         }
     }
 
-    function fillItemFilterList(filterList, settingsItemIds, isExclusion) {
-        if (filterList.hasChildNodes()) {
-            return
-        }
-
-        for (const id of includeInFilter) {
-            for (const bundle of getQuestBundles(id)) {
-                const questItemId = id + '_' + bundle
-                const isActive = settingsItemIds.includes(questItemId) !== isExclusion
-                filterList.appendChild(createFilterButton(
-                    questItemId,
-                    getItemName(id),
-                    '×' + bundle,
-                    getItemImageUrl(id),
-                    isActive
-                ))
-            }
-        }
+    class QuestItemFilterManager extends FilterManager {
+        getListSelector() { return '.quest-item-filter-list' }
+        getTitleSelector() { return '.quest-item-filter-title' }
+        getAllIds() { return questItemIds }
+        getButtonHeader(id) { return getItemName(id.substring(0, id.indexOf('_'))) }
+        getButtonFooter(id) { return '×' + id.substring(id.indexOf('_') + 1) }
+        getButtonIconUrl(id) { return getItemImageUrl(id.substring(0, id.indexOf('_'))) }
+        idFromString(idString) { return idString }
     }
 
-    function configureItemModal(modalId, settingsItemIds, isExclusion) {
-        const modalDiv = document.getElementById(modalId)
-
-        setModalFunction(modalDiv, 'onOpenStart', function () {
-            fillItemFilterList(modalDiv.querySelector('.quest-item-filter-list'), settingsItemIds, isExclusion)
-        })
-    }
-
-    configureItemModal('quest-filter-modal', settings.excludedQuestItems, true)
-    configureItemModal('notif-quest-filter-modal', settings.notifQuestItems, false)
-
-    $('.quest-item-filter-list').on('click', '.filter-button', function () {
-        const inputElement = $(this).parent().parent().find('input[id$=items]')
-        const value = inputElement.val().length > 0 ? inputElement.val().split(',') : []
-        const id = $(this).data('id').toString()
-        if ($(this).hasClass('active')) {
-            inputElement.val((value.concat(id).join(','))).trigger('change')
-            $(this).removeClass('active')
-        } else {
-            inputElement.val(value.filter(function (elem) {
-                return elem !== id
-            }).join(',')).trigger('change')
-            $(this).addClass('active')
+    filterManagers.excludedQuestItems = new QuestItemFilterManager(
+        'quest-filter-modal', 'excludedQuestItems', i18n('Quest Items'), true,
+        () => updatePokestops(),
+        () => {
+            updatePokestops()
+            updateMap({ loadAllPokestops: true })
         }
-    })
+    )
 
-    $('.quest-item-select-all').on('click', function (e) {
-        const parent = $(this).parent().parent().parent()
-        parent.find('.quest-item-filter-list .filter-button:visible').addClass('active')
-        parent.find('input[id$=items]').val('').trigger('change')
-    })
-
-    $('.quest-item-deselect-all').on('click', function (e) {
-        const parent = $(this).parent().parent().parent()
-        parent.find('.quest-item-filter-list .filter-button:visible').removeClass('active')
-        parent.find('input[id$=items]').val(questItemIds.join(',')).trigger('change')
-    })
-
-    $('#exclude-quest-items').val(settings.excludedQuestItems)
-    if (settings.excludedQuestItems.length === 0) {
-        $('a[href="#quest-item-tab"]').text(`${i18n('Quest Items')} (${i18n('All')})`)
-    } else {
-        $('a[href="#quest-item-tab"]').text(`${i18n('Quest Items')} (${questItemIds.length - settings.excludedQuestItems.length})`)
-    }
-
-    $('label[for="exclude-quest-items"] .quest-item-filter-list .filter-button').each(function () {
-        const id = $(this).data('id').toString()
-        if (!settings.excludedQuestItems.includes(id)) {
-            $(this).addClass('active')
-        }
-    })
-
-    $('#exclude-quest-items').on('change', function () {
-        settings.excludedQuestItems = $(this).val().length > 0 ? $(this).val().split(',') : []
-
-        updatePokestops()
-        updateMap({ loadAllPokestops: true })
-
-        if (settings.excludedQuestItems.length === 0) {
-            $('a[href="#quest-item-tab"]').text(`${i18n('Quest Items')} (${i18n('All')})`)
-        } else {
-            $('a[href="#quest-item-tab"]').text(`${i18n('Quest Items')} (${questItemIds.length - settings.excludedQuestItems.length})`)
-        }
-        $('#quest-filter-tabs').tabs('updateTabIndicator')
-
-        Store.set('excludedQuestItems', settings.excludedQuestItems)
-    })
-
-    const noNotifItems = questItemIds.filter(id => !settings.notifQuestItems.includes(id))
-    $('#no-notif-quest-items').val(noNotifItems)
-    if (settings.notifQuestItems.length === questItemIds.length) {
-        $('a[href="#notif-quest-item-tab"]').text(`${i18n('Notif Quest Items')} (${i18n('All')})`)
-    } else {
-        $('a[href="#notif-quest-item-tab"]').text(`${i18n('Notif Quest Items')} (${settings.notifQuestItems.length})`)
-    }
-
-    $('label[for="no-notif-quest-items"] .quest-item-filter-list .filter-button').each(function () {
-        const id = $(this).data('id').toString()
-        if (settings.notifQuestItems.includes(id)) {
-            $(this).addClass('active')
-        }
-    })
-
-    $('#no-notif-quest-items').on('change', function () {
-        const noNotifQuestItems = $(this).val().length > 0 ? $(this).val().split(',') : []
-        settings.notifQuestItems = questItemIds.filter(id => !noNotifQuestItems.includes(id))
-
-        updatePokestops()
-
-        if (settings.notifQuestItems.length === questItemIds.length) {
-            $('a[href="#notif-quest-item-tab"]').text(`${i18n('Notif Quest Items')} (${i18n('All')})`)
-        } else {
-            $('a[href="#notif-quest-item-tab"]').text(`${i18n('Notif Quest Items')} (${settings.notifQuestItems.length})`)
-        }
-        $('#notif-quest-filter-tabs').tabs('updateTabIndicator')
-
-        Store.set('notifQuestItems', settings.notifQuestItems)
-    })
+    filterManagers.notifQuestItems = new QuestItemFilterManager(
+        'notif-quest-filter-modal', 'notifQuestItems', i18n('Notif Quest Items'), false,
+        () => updatePokestops(),
+        () => updatePokestops()
+    )
 }
 
 function initInvasionFilters() {
-    const invasionIds = [41, 42, 43, 44, 5, 4, 6, 7, 10, 11, 12, 13, 49, 50, 14, 15, 16, 17, 18, 19, 20, 21, 47, 48, 22, 23, 24, 25, 26, 27, 30, 31, 32, 33, 34, 35, 36, 37, 28, 29, 38, 39]
+    const invasionIds = new Set([41, 42, 43, 44, 5, 4, 6, 7, 10, 11, 12, 13, 49, 50, 14, 15, 16, 17, 18, 19, 20, 21, 47, 48, 22, 23, 24, 25, 26, 27, 30, 31, 32, 33, 34, 35, 36, 37, 28, 29, 38, 39])
 
-    function fillInvasionFilterList(filterList, settingsInvasionIds, isExclusion) {
-        if (filterList.hasChildNodes()) {
-            return
-        }
-
-        for (const id of invasionIds) {
-            const isActive = settingsInvasionIds.includes(id) !== isExclusion
-            filterList.appendChild(createFilterButton(
-                id,
-                getInvasionType(id),
-                getInvasionGrunt(id),
-                getInvasionImageUrl(id),
-                isActive
-            ))
-        }
+    class InvasionFilterManager extends FilterManager {
+        getListSelector() { return '.invasion-filter-list' }
+        getTitleSelector() { return '.invasion-filter-title' }
+        getAllIds() { return invasionIds }
+        getButtonHeader(id) { return getInvasionType(id) }
+        getButtonFooter(id) { return getInvasionGrunt(id) }
+        getButtonIconUrl(id) { return getInvasionImageUrl(id) }
+        idFromString(idString) { return parseInt(idString) }
     }
 
-    function configureInvasionModal(modalId, settingsInvasionIds, isExclusion) {
-        const modalDiv = document.getElementById(modalId)
-
-        setModalFunction(modalDiv, 'onOpenStart', function () {
-            fillInvasionFilterList(modalDiv.querySelector('.invasion-filter-list'), settingsInvasionIds, isExclusion)
-        })
-    }
-
-    configureInvasionModal('invasion-filter-modal', settings.excludedInvasions, true)
-    configureInvasionModal('notif-invasion-filter-modal', settings.notifInvasions, false)
-
-    $('.invasion-filter-list').on('click', '.filter-button', function () {
-        var inputElement = $(this).parent().parent().find('input[id$=invasions]')
-        var value = inputElement.val().length > 0 ? inputElement.val().split(',') : []
-        var id = $(this).data('id').toString()
-        if ($(this).hasClass('active')) {
-            inputElement.val((value.concat(id).join(','))).trigger('change')
-            $(this).removeClass('active')
-        } else {
-            inputElement.val(value.filter(function (elem) {
-                return elem !== id
-            }).join(',')).trigger('change')
-            $(this).addClass('active')
+    filterManagers.excludedInvasions = new InvasionFilterManager(
+        'invasion-filter-modal', 'excludedInvasions', i18n('Rocket Invasions'), true,
+        () => updatePokestops(),
+        () => {
+            updatePokestops()
+            updateMap({ loadAllPokestops: true })
         }
-    })
+    )
 
-    $('.invasion-select-all').on('click', function (e) {
-        var parent = $(this).parent().parent().parent()
-        parent.find('.invasion-filter-list .filter-button:visible').addClass('active')
-        parent.find('input[id$=invasions]').val('').trigger('change')
-    })
-
-    $('.invasion-deselect-all').on('click', function (e) {
-        var parent = $(this).parent().parent().parent()
-        parent.find('.invasion-filter-list .filter-button:visible').removeClass('active')
-        parent.find('input[id$=invasions]').val(invasionIds.join(',')).trigger('change')
-    })
-
-    $('#exclude-invasions').val(settings.excludedInvasions)
-    if (settings.excludedInvasions.length === 0) {
-        $('#filter-invasion-title').text(`${i18n('Rocket Invasions')} (${i18n('All')})`)
-    } else {
-        $('#filter-invasion-title').text(`${i18n('Rocket Invasions')} (${invasionIds.length - settings.excludedInvasions.length})`)
-    }
-
-    $('label[for="exclude-invasions"] .invasion-filter-list .filter-button').each(function () {
-        if (!settings.excludedInvasions.includes($(this).data('id'))) {
-            $(this).addClass('active')
-        }
-    })
-
-    $('#exclude-invasions').on('change', function () {
-        settings.excludedInvasions = $(this).val().length > 0 ? $(this).val().split(',').map(Number) : []
-
-        updatePokestops()
-        updateMap({ loadAllPokestops: true })
-
-        if (settings.excludedInvasions.length === 0) {
-            $('#filter-invasion-title').text(`${i18n('Rocket Invasions')} (${i18n('All')})`)
-        } else {
-            $('#filter-invasion-title').text(`${i18n('Rocket Invasions')} (${invasionIds.length - settings.excludedInvasions.length})`)
-        }
-
-        Store.set('excludedInvasions', settings.excludedInvasions)
-    })
-
-    const noNotifInvasions = invasionIds.filter(id => !settings.notifInvasions.includes(id))
-    $('#no-notif-invasions').val(noNotifInvasions)
-    if (settings.notifInvasions.length === invasionIds.length) {
-        $('#notif-invasion-filter-title').text(`${i18n('Notif Rocket Invasions')} (${i18n('All')})`)
-    } else {
-        $('#notif-invasion-filter-title').text(`${i18n('Notif Rocket Invasions')} (${settings.notifInvasions.length})`)
-    }
-
-    $('label[for="no-notif-invasions"] .invasion-filter-list .filter-button').each(function () {
-        if (settings.notifInvasions.includes($(this).data('id'))) {
-            $(this).addClass('active')
-        }
-    })
-
-    $('#no-notif-invasions').on('change', function () {
-        const noNotifInvasions = $(this).val().length > 0 ? $(this).val().split(',').map(Number) : []
-        settings.notifInvasions = invasionIds.filter(id => !noNotifInvasions.includes(id))
-
-        updatePokestops()
-
-        if (settings.notifInvasions.length === invasionIds.length) {
-            $('#notif-invasion-filter-title').text(`${i18n('Notif Rocket Invasions')} (${i18n('All')})`)
-        } else {
-            $('#notif-invasion-filter-title').text(`${i18n('Notif Rocket Invasions')} (${settings.notifInvasions.length})`)
-        }
-
-        Store.set('notifInvasions', settings.notifInvasions)
-    })
+    filterManagers.notifInvasions = new InvasionFilterManager(
+        'notif-invasion-filter-modal', 'notifInvasions', i18n('Notif Rocket Invasions'), false,
+        () => updatePokestops(),
+        () => updatePokestops()
+    )
 }
 
 function initBackupModals() {
@@ -2387,10 +2048,10 @@ function initBackupModals() {
     }
 
     function loaded(e) {
-        var fileString = e.target.result
-        var checkBoxSelected = false
+        const fileString = e.target.result
+        let checkBoxSelected = false
 
-        var pokemons = null
+        let pokemons = null
         try {
             pokemons = JSON.parse(fileString)
         } catch (e) {
@@ -2400,117 +2061,54 @@ function initBackupModals() {
             toastError(i18n('Error while reading Pokémon list file!'), i18n('Check your Pokémon list file.'))
             return
         }
-        for (var i = 0; i < pokemons.length; i++) {
+        for (let i = 0; i < pokemons.length; i++) {
             if (!Number.isInteger(pokemons[i])) {
                 toastError(i18n('Unexpected character found in Pokémon list file!'), i18n('Check your Pokémon list file.'))
                 return
             }
         }
 
-        const excludedPokemon = Array.from(pokemonIds).filter(id => !pokemons.includes(id))
+        const excludedPokemons = difference(pokemonIds, new Set(pokemons))
 
-        if (serverSettings.pokemons && $('#import-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#exclude-pokemon').val(excludedPokemon).trigger('change')
-
-            $('label[for="exclude-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (!settings.excludedPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        function importFiltersIfChecked(checkBoxId, filterManager) {
+            const checkBox = document.getElementById(checkBoxId)
+            if (checkBox && checkBox.checked && filterManager) {
+                checkBoxSelected = true
+                filterManager.clear()
+                filterManager.isExclusion ? filterManager.add(excludedPokemons) : filterManager.add(pokemons)
+            }
         }
 
-        if (serverSettings.pokemonValues && $('#import-values-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#unfiltered-pokemon').val(excludedPokemon).trigger('change')
-
-            $('label[for="unfiltered-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (!settings.noFilterValuesPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        if (serverSettings.pokemons) {
+            importFiltersIfChecked('import-pokemon-checkbox', filterManagers.excludedPokemon)
         }
 
-        if (serverSettings.raids && $('#import-raid-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#exclude-raid-pokemon').val(excludedPokemon).trigger('change')
-
-            $('label[for="exclude-raid-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (!settings.excludedRaidPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        if (serverSettings.pokemonValues) {
+            importFiltersIfChecked('import-values-pokemon-checkbox', filterManagers.noFilterValuesPokemon)
         }
 
-        if (serverSettings.quests && $('#import-quest-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#exclude-quest-pokemon').val(excludedPokemon).trigger('change')
-
-            $('label[for="exclude-quest-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (!settings.excludedQuestPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        if (serverSettings.raids) {
+            importFiltersIfChecked('import-raid-pokemon-checkbox', filterManagers.excludedRaidPokemon)
         }
 
-        if (serverSettings.pokemons && $('#import-notif-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#no-notif-pokemon').val(excludedPokemon).trigger('change')
-
-            $('label[for="no-notif-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (settings.notifPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        if (serverSettings.quests) {
+            importFiltersIfChecked('import-quest-pokemon-checkbox', filterManagers.excludedQuestPokemon)
         }
 
-        if (serverSettings.pokemonValues && $('#import-notif-values-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#no-notif-values-pokemon').val(excludedPokemon).trigger('change')
-
-            $('label[for="no-notif-values-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (settings.notifValuesPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        if (serverSettings.pokemons) {
+            importFiltersIfChecked('import-notif-pokemon-checkbox', filterManagers.notifPokemon)
         }
 
-        if (serverSettings.raids && $('#import-notif-raid-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#no-notif-raid-pokemon').val(excludedPokemon).trigger('change')
-
-            $('label[for="no-notif-raid-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (settings.notifRaidPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        if (serverSettings.pokemonValues) {
+            importFiltersIfChecked('import-notif-values-pokemon-checkbox', filterManagers.notifValuesPokemon)
         }
 
-        if (serverSettings.quests && $('#import-notif-quest-pokemon-checkbox').is(':checked')) {
-            checkBoxSelected = true
-            $('#no-notif-quest-pokemon').val(excludedPokemon).trigger('change')
+        if (serverSettings.raids) {
+            importFiltersIfChecked('import-notif-raid-pokemon-checkbox', filterManagers.notifRaidPokemon)
+        }
 
-            $('label[for="no-notif-quest-pokemon"] .pokemon-filter-list .filter-button').each(function () {
-                if (settings.notifQuestPokemon.has($(this).data('id'))) {
-                    $(this).addClass('active')
-                } else {
-                    $(this).removeClass('active')
-                }
-            })
+        if (serverSettings.quests) {
+            importFiltersIfChecked('import-notif-quest-pokemon-checkbox', filterManagers.notifQuestPokemon)
         }
 
         if (checkBoxSelected) {

--- a/static/js/map/map.stats.js
+++ b/static/js/map/map.stats.js
@@ -36,8 +36,6 @@ function initStatsSidebar() {
     })
 
     function initStatsTables() {
-        console.log('initStatsTables')
-
         $('#stats-tabs').tabs({
             onShow: updateStatsTable
         })

--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -276,8 +276,8 @@ const StoreOptions = {
         type: StoreTypes.Set
     },
     excludedQuestItems: {
-        default: [],
-        type: StoreTypes.JSON
+        default: new Set(),
+        type: StoreTypes.Set
     },
     showInvasions: {
         default: true,
@@ -292,8 +292,8 @@ const StoreOptions = {
         type: StoreTypes.Boolean
     },
     excludedInvasions: {
-        default: [],
-        type: StoreTypes.JSON
+        default: new Set(),
+        type: StoreTypes.Set
     },
     includedLureTypes: {
         default: [501, 502, 503, 504],
@@ -312,16 +312,16 @@ const StoreOptions = {
         type: StoreTypes.Set
     },
     notifQuestItems: {
-        default: [],
-        type: StoreTypes.JSON
+        default: new Set(),
+        type: StoreTypes.Set
     },
     invasionNotifs: {
         default: false,
         type: StoreTypes.Boolean
     },
     notifInvasions: {
-        default: [],
-        type: StoreTypes.JSON
+        default: new Set(),
+        type: StoreTypes.Set
     },
     notifLureTypes: {
         default: [],

--- a/static/sass/components/_modal.scss
+++ b/static/sass/components/_modal.scss
@@ -118,10 +118,10 @@
   .pokemon-filter-list, .quest-item-filter-list, .invasion-filter-list {
     overflow-y: hidden;
   }
-}
 
-.pokemon-filter-modal, .quest-filter-modal {
-  min-height: 80vh;
+  .pokemon-filter-list {
+    min-height: 80vh;
+  }
 }
 
 .dark .filter-modal {

--- a/templates/map.html
+++ b/templates/map.html
@@ -179,7 +179,7 @@
     {% if settings.pokemons %}
     <div id="pokemon-filter-modal" class="modal filter-modal pokemon-filter-modal">
       <div class="modal-content">
-        <h6 id="filter-pokemon-title">Pokémon</h6>
+        <h6 class="pokemon-filter-title">{{ i18n('Pokémon') }}</h6>
         <label for="exclude-pokemon">
           <input id="exclude-pokemon" type="text" readonly="true" style="display:none;">
           <div class="pokemon-filter-list"></div>
@@ -189,10 +189,8 @@
               <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
             </div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-              <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>
@@ -203,7 +201,7 @@
     {% if settings.pokemonValues %}
     <div id="pokemon-values-filter-modal" class="modal filter-modal pokemon-filter-modal">
       <div class="modal-content">
-        <h6 id="filter-values-pokemon-title">{{ i18n('Pokémon filtered by values') }}</h6>
+        <h6 class="pokemon-filter-title">{{ i18n('Pokémon filtered by values') }}</h6>
         <label for="unfiltered-pokemon">
           <input id="unfiltered-pokemon" type="text" readonly="true" style="display:none;">
           <div class="pokemon-filter-list"></div>
@@ -213,10 +211,8 @@
               <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
             </div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-              <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>
@@ -227,7 +223,7 @@
     {% if settings.raidFilters %}
     <div id="raid-pokemon-filter-modal" class="modal filter-modal pokemon-filter-modal">
       <div class="modal-content">
-        <h6 id="filter-raid-pokemon-title">Raid Bosses</h6>
+        <h6 class="pokemon-filter-title">{{ i18n('Raid Bosses') }}</h6>
         <label for="exclude-raid-pokemon">
           <input id="exclude-raid-pokemon" type="text" readonly="true" style="display:none;">
           <div class="pokemon-filter-list"></div>
@@ -237,10 +233,8 @@
               <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
             </div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-              <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>
@@ -252,8 +246,8 @@
     <div id="quest-filter-modal" class="modal filter-modal quest-filter-modal">
       <div class="modal-content">
         <ul id="quest-filter-tabs" class="tabs quest-filter-tabs">
-          <li class="tab"><a href="#quest-pokemon-tab" class="active">Quest Pokémon</a></li>
-          <li class="tab"><a href="#quest-item-tab">Quest Items</a></li>
+          <li class="tab"><a href="#quest-pokemon-tab" class="pokemon-filter-title active">Quest Pokémon</a></li>
+          <li class="tab"><a href="#quest-item-tab" class="quest-item-filter-title">{{ i18n('Quest Items') }}</a></li>
         </ul>
         <div id="quest-pokemon-tab">
           <label for="exclude-quest-pokemon">
@@ -265,10 +259,8 @@
                 <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
               </div>
               <div class="filter-footer-right">
-                <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-                <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-                <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-                <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+                <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+                <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
               </div>
             </div>
           </label>
@@ -280,8 +272,8 @@
             <div class="filter-footer-container">
               <div></div>
               <div class="filter-footer-right">
-                <a class="waves-effect btn-flat quest-item-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-                <a class="waves-effect btn-flat quest-item-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+                <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+                <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
               </div>
             </div>
           </label>
@@ -293,15 +285,15 @@
     {% if settings.invasions %}
     <div id="invasion-filter-modal" class="modal filter-modal invasion-filter-modal">
       <div class="modal-content">
-        <h6 id="filter-invasion-title">Rocket Invasions</h6>
+        <h6 class="invasion-filter-title">{{ i18n('Rocket Invasions') }}</h6>
         <label for="exclude-invasions">
           <input id="exclude-invasions" type="text" readonly="true" style="display:none;">
           <div class="invasion-filter-list"></div>
           <div class="filter-footer-container">
             <div></div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat invasion-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat invasion-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>
@@ -323,7 +315,7 @@
     {% if settings.pokemons %}
     <div id="notif-pokemon-filter-modal" class="modal filter-modal pokemon-filter-modal">
       <div class="modal-content">
-        <h6 id="notif-pokemon-filter-title">Notif Pokémon</h6>
+        <h6 class="pokemon-filter-title">{{ i18n('Notif Pokémon') }}</h6>
         <label for="no-notif-pokemon">
           <input id="no-notif-pokemon" type="text" readonly="true" style="display:none;">
           <div class="pokemon-filter-list"></div>
@@ -333,10 +325,8 @@
               <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
             </div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-              <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>
@@ -347,7 +337,7 @@
     {% if settings.pokemonValues %}
     <div id="notif-pokemon-values-filter-modal" class="modal filter-modal pokemon-filter-modal">
       <div class="modal-content">
-        <h6 id="notif-pokemon-values-filter-title">{{ i18n('Notif Pokémon filtered by values') }}</h6>
+        <h6 class="pokemon-filter-title">{{ i18n('Notif Pokémon filtered by values') }}</h6>
         <label for="no-notif-values-pokemon">
           <input id="no-notif-values-pokemon" type="text" readonly="true" style="display:none;">
           <div class="pokemon-filter-list"></div>
@@ -357,10 +347,8 @@
               <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
             </div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-              <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>
@@ -371,7 +359,7 @@
     {% if settings.raids %}
     <div id="notif-raid-pokemon-filter-modal" class="modal filter-modal pokemon-filter-modal">
       <div class="modal-content">
-        <h6 id="notif-raid-pokemon-filter-title">Notif Raid Bosses</h6>
+        <h6 class="pokemon-filter-title">{{ i18n('Notif Raid Bosses') }}</h6>
         <label for="no-notif-raid-pokemon">
           <input id="no-notif-raid-pokemon" type="text" readonly="true" style="display:none;">
           <div class="pokemon-filter-list"></div>
@@ -381,10 +369,8 @@
               <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
             </div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-              <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>
@@ -396,8 +382,8 @@
     <div id="notif-quest-filter-modal" class="modal filter-modal quest-filter-modal">
       <div class="modal-content">
         <ul id="notif-quest-filter-tabs" class="tabs quest-filter-tabs">
-          <li class="tab"><a href="#notif-quest-pokemon-tab" class="active">Notif Quest Pokémon</a></li>
-          <li class="tab"><a href="#notif-quest-item-tab">Notif Quest Items</a></li>
+          <li class="tab"><a href="#notif-quest-pokemon-tab" class="pokemon-filter-title active">{{ i18n('Notif Quest Pokémon') }}</a></li>
+          <li class="tab"><a href="#notif-quest-item-tab" class="quest-item-filter-title">{{ i18n('Notif Quest Items') }}</a></li>
         </ul>
         <div id="notif-quest-pokemon-tab">
           <label for="no-notif-quest-pokemon">
@@ -409,10 +395,8 @@
                 <input type="search" class="search" placeholder="{{ i18n('Search...') }}">
               </div>
               <div class="filter-footer-right">
-                <a class="waves-effect btn-flat pokemon-select-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-                <a class="waves-effect btn-flat pokemon-deselect-filtered" style="display:none;"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
-                <a class="waves-effect btn-flat pokemon-select-all"><i class="material-icons" title="Select all">select_all</i></a>
-                <a class="waves-effect btn-flat pokemon-deselect-all"><i class="material-icons" title="Deselect all">delete_forever</i></a>
+                <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="Select all">select_all</i></a>
+                <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="Deselect all">delete_forever</i></a>
               </div>
             </div>
           </label>
@@ -424,8 +408,8 @@
             <div class="filter-footer-container">
               <div></div>
               <div class="filter-footer-right">
-                <a class="waves-effect btn-flat quest-item-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-                <a class="waves-effect btn-flat quest-item-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+                <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+                <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
               </div>
             </div>
           </label>
@@ -437,15 +421,15 @@
     {% if settings.invasions %}
     <div id="notif-invasion-filter-modal" class="modal filter-modal invasion-filter-modal">
       <div class="modal-content">
-        <h6 id="notif-invasion-filter-title">Notif Rocket Invasions</h6>
+        <h6 class="invasion-filter-title">{{ i18n('Notif Rocket Invasions') }}</h6>
         <label for="no-notif-invasions">
           <input id="no-notif-invasions" type="text" readonly="true" style="display:none;">
           <div class="invasion-filter-list"></div>
           <div class="filter-footer-container">
             <div></div>
             <div class="filter-footer-right">
-              <a class="waves-effect btn-flat invasion-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
-              <a class="waves-effect btn-flat invasion-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
+              <a class="waves-effect btn-flat filter-select-all"><i class="material-icons" title="{{ i18n('Select all') }}">select_all</i></a>
+              <a class="waves-effect btn-flat filter-deselect-all"><i class="material-icons" title="{{ i18n('Deselect all') }}">delete_forever</i></a>
             </div>
           </div>
         </label>


### PR DESCRIPTION
After PR #182, marker popup buttons didn't work unless the corresponding filter modal has been opened at least once before.
Importing pokémon list was also partially broken (worked, but required a refresh).

This PR fix these, but the changes are quite consequent. This is basically a refactoring of filters to avoid completely depending on a loaded UI. It also has the benefit of removing almost 400 lines of similar code in `map.settings.js`. Assigning to an hidden input then splitting its content is gone, everything affects directly in-memory settings.

I've retested all 12 filters, all popup buttons and pokemon list imports.

This PR also fixes two existing cases (prior to PR #182) of stops not being correctly updated if the *pokéstops without event* option was enabled and some filters were toggled.

In settings code, quest item filters and intrusion filters are now sets instead of arrays to share the same code path as pokémon filters (they already had unique elements anyway).