### PR TITLE
Check pogo_assets folder itself

### DIFF
--- a/rocketmad/dyn_img.py
+++ b/rocketmad/dyn_img.py
@@ -123,7 +123,8 @@ class ImageGenerator:
                 if args.pogo_assets:
                     pokemon_dirs = [
                         Path(args.pogo_assets) / 'pokemon_icons',
-                        Path(args.pogo_assets) / 'Images/Pokemon - 256x256'
+                        Path(args.pogo_assets) / 'Images/Pokemon - 256x256',
+                        Path(args.pogo_assets)
                     ]
                     for pokemon_dir in pokemon_dirs:
                         if pokemon_dir.exists():


### PR DESCRIPTION
Hey there, 

here's a small improvement for pogo assets dirs: After checking the subdirs, check the folder itself.

This will help stupid users using the subdir path and not the root dir (not including me of course) as well as users who just download (via script & cron for sure) the pogo assets icon files and not all that unnecessary git overhead and therefore do not have the necessity of having 'pokemon_icons' or  'Images/Pokemon - 256x256' subfolders.

So would be nice for stupid as well as advanced users if this could be merged.

Thanks,
🍪 ✌️
