### PR TITLE
Enable filter when using hide on lables.

### DIFF
--- a/static/js/map/map.gym.js
+++ b/static/js/map/map.gym.js
@@ -627,6 +627,9 @@ function excludeRaidLevel(level) { // eslint-disable-line no-unused-vars
 }
 
 function excludeRaidPokemon(id) { // eslint-disable-line no-unused-vars
+    if (!settings.filterRaidPokemon) {
+        $('#filter-raid-pokemon-switch').click()
+    }
     if (filterManagers.excludedRaidPokemon !== null) {
         filterManagers.excludedRaidPokemon.add([id])
     }

--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -453,6 +453,9 @@ function getExcludedPokemon() {
 }
 
 function excludePokemon(id) { // eslint-disable-line no-unused-vars
+    if (!settings.filterPokemonById) {
+        $('#filter-pokemon-switch').click()
+    }
     if (filterManagers.excludedPokemon !== null) {
         filterManagers.excludedPokemon.add([id])
     }

--- a/static/js/map/map.pokestop.js
+++ b/static/js/map/map.pokestop.js
@@ -513,18 +513,27 @@ function removePokestop(pokestop) {
 }
 
 function excludeQuestPokemon(id) { // eslint-disable-line no-unused-vars
+    if (!settings.filterQuests) {
+        $('#filter-quests-switch').click()
+    }
     if (filterManagers.excludedQuestPokemon !== null) {
         filterManagers.excludedQuestPokemon.add([id])
     }
 }
 
 function excludeQuestItem(id, bundle) { // eslint-disable-line no-unused-vars
+    if (!settings.filterQuests) {
+        $('#filter-quests-switch').click()
+    }
     if (filterManagers.excludedQuestItems !== null) {
         filterManagers.excludedQuestItems.add([id + '_' + bundle])
     }
 }
 
 function excludeInvasion(id) { // eslint-disable-line no-unused-vars
+    if (!settings.filterInvasions) {
+        $('#filter-invasions-switch').click()
+    }
     if (filterManagers.excludedInvasions !== null) {
         filterManagers.excludedInvasions.add([id])
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If Pokemon/Raid/Quest/Rocket filter are disabled the **hide** (slashed eye) button on the associated label has no effect and is not working anymore.

Clicking **hide** should remove all Pokemon/Raids/Quests/Rockets of the id/type.
This PR make **hide** working again by enabling the associated filter when clicking the button.

If someone has another solution, we can work on this. Even removing non-functional buttons.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running this for a while on my map.




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.

