### PR TITLE
Dockerfile: optimize size and build time by multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,33 +3,49 @@
 #   docker build -t rocketmap .
 #   docker run -d -P rocketmap -a ptc -u YOURUSERNAME -p YOURPASSWORD -l "Seattle, WA" -st 10 --gmaps-key CHECKTHEWIKI
 
-FROM python:3.6-slim
+# Stage 0: build static assets using Node
+FROM node:12-slim
 
-# Default port the webserver runs on
-EXPOSE 5000
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates git unzip \
+ && npm install
+
+COPY Gruntfile.js static01.zip /usr/src/app/
+COPY static /usr/src/app/static
+
+# Build the assets - later we'll copy it to the app's image
+RUN npm run build
+
+
+# Stage 1: Build the actual image
+FROM python:3.6-slim
 
 # Working directory for the application
 WORKDIR /usr/src/app
 
-# Set Entrypoint with hard-coded options
-ENTRYPOINT ["dumb-init", "-r", "15:2", "python", "./runserver.py", "--host", "0.0.0.0"]
+COPY requirements.txt /usr/src/app
 
-
-COPY package.json requirements.txt Gruntfile.js static01.zip /usr/src/app/
-COPY static /usr/src/app/static
-
+# Install app's dependencies
 RUN apt-get update \
- && apt-get install -y --no-install-recommends curl \
- && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
  && apt-get install -y --no-install-recommends \
-        build-essential git imagemagick nodejs unzip \
+        build-essential curl imagemagick \
  && pip install --no-cache-dir dumb-init \
  && pip install --no-cache-dir -r requirements.txt \
- && npm install \
- && npm run build \
- && rm -rf node_modules \
  && rm -rf /var/lib/apt/lists/* \
- && apt-get purge -y --auto-remove build-essential git nodejs unzip
+ && apt-get purge -y --auto-remove build-essential
+
+# Default port the webserver runs on
+EXPOSE 5000
 
 # Copy everything to the working directory (Python files, templates, config) in one go.
 COPY . /usr/src/app/
+# Copy compiled statics from stage 0
+COPY --from=0 /usr/src/app/static /usr/src/app/static
+
+# Set Entrypoint with hard-coded options
+ENTRYPOINT ["dumb-init", "-r", "15:2", "python", "./runserver.py", "--host", "0.0.0.0"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Build split into multistage build - in first stage Node base image is used for building static assets, which are later included into image with remaining runtime dependencies. This shaves off approximately another 70 MB from the resulting image size and makes the build faster, when static assets are changed, only step with npm build is executed, remaining layers are cached.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When Docker build is part of the deployment process, every minor change in the `static` folder triggers basically complete rebuild of the container. Multi-stage build allows for faster build with even smaller footprint.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed on personal instance, no issues found.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
