### PR TITLE
Add S2 Cells for Levels 11, 12, 15, 16

### DIFF
--- a/static/js/map/map.js
+++ b/static/js/map/map.js
@@ -115,8 +115,12 @@ const settings = {
     showNestParks: null,
     showS2Cells: null,
     showS2CellsLevel10: null,
+    showS2CellsLevel11: null,
+    showS2CellsLevel12: null,
     showS2CellsLevel13: null,
     showS2CellsLevel14: null,
+    showS2CellsLevel15: null,
+    showS2CellsLevel16: null,
     showS2CellsLevel17: null,
     warnHiddenS2Cells: null,
     showRanges: null,
@@ -1300,7 +1304,7 @@ $(function () {
         // Initial load.
         return updateMap()
     }).catch(function () {
-        // updateMap() failed... ¯\_(ツ)_/¯
+        // updateMap() failed... ¯\_(?)_/¯
     }).then(function () {
         initPokemonFilters()
         if (serverSettings.quests) {

--- a/static/js/map/map.js
+++ b/static/js/map/map.js
@@ -1304,7 +1304,7 @@ $(function () {
         // Initial load.
         return updateMap()
     }).catch(function () {
-        // updateMap() failed... ¯\_(?)_/¯
+        // updateMap() failed... ¯\_(ツ)_/¯
     }).then(function () {
         initPokemonFilters()
         if (serverSettings.quests) {

--- a/static/js/map/map.s2.js
+++ b/static/js/map/map.s2.js
@@ -64,6 +64,22 @@ function updateS2Overlay() {
             }
         }
 
+        if (settings.showS2CellsLevel16) {
+            if (zoomLevel > 13) {
+                showS2Cells(16, 'orange', 1)
+            } else if (settings.warnHiddenS2Cells) {
+                toastWarning(i18n('S2 Level 16 cells are hidden!'), i18n('Zoom in more to show them.'))
+            }
+        }
+
+        if (settings.showS2CellsLevel15) {
+            if (zoomLevel > 12) {
+                showS2Cells(15, 'green', 1)
+            } else if (settings.warnHiddenS2Cells) {
+                toastWarning(i18n('S2 Level 15 cells are hidden!'), i18n('Zoom in more to show them.'))
+            }
+        }
+
         if (settings.showS2CellsLevel14) {
             if (zoomLevel > 11) {
                 showS2Cells(14, 'red', 1.5)
@@ -77,6 +93,22 @@ function updateS2Overlay() {
                 showS2Cells(13, 'black', 2)
             } else if (settings.warnHiddenS2Cells) {
                 toastWarning(i18n('EX trigger cells are hidden!'), i18n('Zoom in more to show them.'))
+            }
+        }
+
+        if (settings.showS2CellsLevel12) {
+            if (zoomLevel > 9) {
+                showS2Cells(12, 'purple', 2)
+            } else if (settings.warnHiddenS2Cells) {
+                toastWarning(i18n('S2 Level 12 cells are hidden!'), i18n('Zoom in more to show them.'))
+            }
+        }
+
+        if (settings.showS2CellsLevel11) {
+            if (zoomLevel > 8) {
+                showS2Cells(11, 'yellow', 2)
+            } else if (settings.warnHiddenS2Cells) {
+                toastWarning(i18n('S2 Level 11 cells are hidden!'), i18n('Zoom in more to show them.'))
             }
         }
 

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -117,8 +117,12 @@ function initSettings() {
     settings.showS2Cells = serverSettings.s2Cells && Store.get('showS2Cells')
     if (serverSettings.s2Cells) {
         settings.showS2CellsLevel10 = Store.get('showS2CellsLevel10')
+        settings.showS2CellsLevel11 = Store.get('showS2CellsLevel11')
+        settings.showS2CellsLevel12 = Store.get('showS2CellsLevel12')
         settings.showS2CellsLevel13 = Store.get('showS2CellsLevel13')
         settings.showS2CellsLevel14 = Store.get('showS2CellsLevel14')
+        settings.showS2CellsLevel15 = Store.get('showS2CellsLevel15')
+        settings.showS2CellsLevel16 = Store.get('showS2CellsLevel16')
         settings.showS2CellsLevel17 = Store.get('showS2CellsLevel17')
         settings.warnHiddenS2Cells = Store.get('warnHiddenS2Cells')
     }
@@ -794,6 +798,18 @@ function initSettingsSidebar() {
             Store.set('showS2CellsLevel10', this.checked)
         })
 
+        $('#s2-level11-switch').on('change', function () {
+            settings.showS2CellsLevel11 = this.checked
+            updateS2Overlay()
+            Store.set('showS2CellsLevel11', this.checked)
+        })
+
+        $('#s2-level12-switch').on('change', function () {
+            settings.showS2CellsLevel12 = this.checked
+            updateS2Overlay()
+            Store.set('showS2CellsLevel12', this.checked)
+        })
+
         $('#s2-level13-switch').on('change', function () {
             settings.showS2CellsLevel13 = this.checked
             updateS2Overlay()
@@ -804,6 +820,18 @@ function initSettingsSidebar() {
             settings.showS2CellsLevel14 = this.checked
             updateS2Overlay()
             Store.set('showS2CellsLevel14', this.checked)
+        })
+
+        $('#s2-level15-switch').on('change', function () {
+            settings.showS2CellsLevel15 = this.checked
+            updateS2Overlay()
+            Store.set('showS2CellsLevel15', this.checked)
+        })
+
+        $('#s2-level16-switch').on('change', function () {
+            settings.showS2CellsLevel16 = this.checked
+            updateS2Overlay()
+            Store.set('showS2CellsLevel16', this.checked)
         })
 
         $('#s2-level17-switch').on('change', function () {
@@ -1457,8 +1485,12 @@ function initSettingsSidebar() {
         $('#s2-cell-switch').prop('checked', settings.showS2Cells)
         $('#s2-filters-wrapper').toggle(settings.showS2Cells)
         $('#s2-level10-switch').prop('checked', settings.showS2CellsLevel10)
+        $('#s2-level11-switch').prop('checked', settings.showS2CellsLevel11)
+        $('#s2-level12-switch').prop('checked', settings.showS2CellsLevel12)
         $('#s2-level13-switch').prop('checked', settings.showS2CellsLevel13)
         $('#s2-level14-switch').prop('checked', settings.showS2CellsLevel14)
+        $('#s2-level15-switch').prop('checked', settings.showS2CellsLevel15)
+        $('#s2-level16-switch').prop('checked', settings.showS2CellsLevel16)
         $('#s2-level17-switch').prop('checked', settings.showS2CellsLevel17)
         $('#s2-cells-warning-switch').prop('checked', settings.warnHiddenS2Cells)
     }

--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -367,12 +367,28 @@ const StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
+    showS2CellsLevel11: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    showS2CellsLevel12: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
     showS2CellsLevel13: {
         default: true,
         type: StoreTypes.Boolean
     },
     showS2CellsLevel14: {
         default: true,
+        type: StoreTypes.Boolean
+    },
+    showS2CellsLevel15: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    showS2CellsLevel16: {
+        default: false,
         type: StoreTypes.Boolean
     },
     showS2CellsLevel17: {

--- a/templates/map.html
+++ b/templates/map.html
@@ -1022,6 +1022,24 @@
               <div class="form-control">
                 <div class="switch">
                   <label>
+                    <input type="checkbox" id="s2-level11-switch">
+                    <span class="lever"></span>
+                    {{ i18n('S2 Level 11 cells') }} (S2 L11)
+                  </label>
+                </div>
+              </div>
+              <div class="form-control">
+                <div class="switch">
+                  <label>
+                    <input type="checkbox" id="s2-level12-switch">
+                    <span class="lever"></span>
+                    {{ i18n('S2 Level 12 cells') }} (S2 L12)
+                  </label>
+                </div>
+              </div>
+              <div class="form-control">
+                <div class="switch">
+                  <label>
                     <input type="checkbox" id="s2-level13-switch">
                     <span class="lever"></span>
                     {{ i18n('Ex trigger cells') }} (S2 L13)
@@ -1034,6 +1052,24 @@
                     <input type="checkbox" id="s2-level14-switch">
                     <span class="lever"></span>
                     {{ i18n('Gym cells') }} (S2 L14)
+                  </label>
+                </div>
+              </div>
+              <div class="form-control">
+                <div class="switch">
+                  <label>
+                    <input type="checkbox" id="s2-level15-switch">
+                    <span class="lever"></span>
+                    {{ i18n('S2 Level 15 cells') }} (S2 L15)
+                  </label>
+                </div>
+              </div>
+              <div class="form-control">
+                <div class="switch">
+                  <label>
+                    <input type="checkbox" id="s2-level16-switch">
+                    <span class="lever"></span>
+                    {{ i18n('S2 Level 16 cells') }} (S2 L16)
                   </label>
                 </div>
               </div>


### PR DESCRIPTION
## Description
Add S2 Cells for Levels 11, 12, 15, 16

## Motivation and Context
This will help with visualizing different S2 Levels within RM so users can find correlations in data grouping that are not covered by existing S2 levels.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
