### PR TITLE
update node-sass to 6.0.1 to support Node v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "grunt-sass": "^3.1.0",
     "grunt-zip": "^0.18.2",
     "jit-grunt": "^0.10.0",
-    "node-sass": "^4.14.1"
+    "node-sass": "^6.0.1",
+    "sass": "^1.35.1"
   },
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
node-sass 6.x is required to support NodeJS v16.x otherwise `run build` (and probably other things) will fail.