### PR TITLE
Fix negative time results from getTimeUntil

### DIFF
--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -204,7 +204,7 @@ function getTimeUntil(time, now) {
     let min = roundFunction((tdiff / 1000 / 60) % 60)
     let hour = roundFunction((tdiff / (1000 * 60 * 60)) % 24)
 
-    if (min < 0) sec = Math.abs(sec)
+    if (hour < 0 || min < 0) sec = Math.abs(sec)
     if (hour < 0) min = Math.abs(min)
 
     return {

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -209,7 +209,7 @@ function getTimeUntil(time) {
     var min = Math.floor((tdiff / 1000 / 60) % 60)
     var hour = Math.floor((tdiff / (1000 * 60 * 60)) % 24)
 
-    if (negTimeUntil == 1) {
+    if (negTimeUntil === 1) {
       tdiff *= -1
       if (hour > 0) hour *= -1
       else if (min > 0) min *= -1

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -194,8 +194,8 @@ function isNowBetween(timestamp1, timestamp2) {
     return timestamp1 <= now && now <= timestamp2
 }
 
-function getTimeUntil(time, now) {
-    // let now = Date.now()
+function getTimeUntil(time) {
+    let now = Date.now()
     let tdiff = time - now
     let roundFunction = tdiff < 0 ? Math.ceil : Math.floor
     if (tdiff < 0) tdiff -= 1000

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -194,27 +194,18 @@ function isNowBetween(timestamp1, timestamp2) {
     return timestamp1 <= now && now <= timestamp2
 }
 
-function getTimeUntil(time) {
-    var now = Date.now()
-    var tdiff = time - now
+function getTimeUntil(time, now) {
+    // let now = Date.now()
+    let tdiff = time - now
+    let roundFunction = tdiff < 0 ? Math.ceil : Math.floor
+    if (tdiff < 0) tdiff -= 1000
 
-    var negTimeUntil = false
-    if (tdiff < 0) {
-        negTimeUntil = true
-        tdiff *= -1
-        tdiff += 1000
-    }
+    let sec = roundFunction((tdiff / 1000) % 60)
+    let min = roundFunction((tdiff / 1000 / 60) % 60)
+    let hour = roundFunction((tdiff / (1000 * 60 * 60)) % 24)
 
-    var sec = Math.floor((tdiff / 1000) % 60)
-    var min = Math.floor((tdiff / 1000 / 60) % 60)
-    var hour = Math.floor((tdiff / (1000 * 60 * 60)) % 24)
-
-    if (negTimeUntil) {
-      tdiff *= -1
-      if (hour > 0) hour *= -1
-      else if (min > 0) min *= -1
-      else sec *= -1
-    }
+    if (min < 0) sec = Math.abs(sec)
+    if (hour < 0) min = Math.abs(min)
 
     return {
         total: tdiff,
@@ -241,7 +232,7 @@ function updateLabelDiffTime() {
 
         if (disappearsAt.ttime < disappearsAt.now) {
             timestring = 'expired'
-        } else if (hours > 0) {
+        } else if (hours != 0) {
             timestring = lpad(hours, 2, 0) + 'h' + lpad(minutes, 2, 0) + 'm' + lpad(seconds, 2, 0) + 's'
         } else {
             timestring = lpad(minutes, 2, 0) + 'm' + lpad(seconds, 2, 0) + 's'

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -198,9 +198,9 @@ function getTimeUntil(time) {
     var now = Date.now()
     var tdiff = time - now
 
-    var negTimeUntil = 0
+    var negTimeUntil = false
     if (tdiff < 0) {
-        negTimeUntil = 1
+        negTimeUntil = true
         tdiff *= -1
         tdiff += 1000
     }
@@ -209,7 +209,7 @@ function getTimeUntil(time) {
     var min = Math.floor((tdiff / 1000 / 60) % 60)
     var hour = Math.floor((tdiff / (1000 * 60 * 60)) % 24)
 
-    if (negTimeUntil === 1) {
+    if (negTimeUntil) {
       tdiff *= -1
       if (hour > 0) hour *= -1
       else if (min > 0) min *= -1

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -198,9 +198,23 @@ function getTimeUntil(time) {
     var now = Date.now()
     var tdiff = time - now
 
+    var negTimeUntil = 0
+    if (tdiff < 0) {
+        negTimeUntil = 1
+        tdiff *= -1
+        tdiff += 1000
+    }
+
     var sec = Math.floor((tdiff / 1000) % 60)
     var min = Math.floor((tdiff / 1000 / 60) % 60)
     var hour = Math.floor((tdiff / (1000 * 60 * 60)) % 24)
+
+    if (negTimeUntil == 1) {
+      tdiff *= -1
+      if (hour > 0) hour *= -1
+      else if (min > 0) min *= -1
+      else sec *= -1
+    }
 
     return {
         total: tdiff,


### PR DESCRIPTION
Previously, getTimeUntil would return results that looked like:
time remaining: 00m01s, 00m00s, -1m-01s, -1m-02s, etc, -1m-59s, -2m-00s, -2m-01s, etc
Since it was using the floor on division, when the input went negative, it would instantly be off by a negative minute, and both the minute and seconds were negative.
This change fixes the rounding problem and only returns a single negative number, which now looks like:
time remaining: 00m01s, 00m00s, 00m-01s, 00m-02s, etc, 00m-59s, -1m00s, -1m01s, etc

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've implemented this change on my server and the remaining time is now displayed as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
