### PR TITLE
Add weather and boosted types to gym pop-up

### DIFF
--- a/static/js/map/map.gym.js
+++ b/static/js/map/map.gym.js
@@ -421,6 +421,29 @@ function gymLabel(gym) {
         }
     }
 
+    const gymS2CellId = S2.toId(S2.S2Cell.FromLatLng({ lat: gym.latitude, lng: gym.longitude }, 10).toHilbertQuadkey());
+    const weather = mapData.weather[gymS2CellId]
+    if (weather) {
+        weatherDisplay = $('<div class="wsnowrap" style="margin-top:3px;" />')
+        $('<img />',
+            { src: getWeatherIconUrl(weather),
+              title: i18n(weatherNames[weather.gameplay_weather]),
+              width: 20
+            }).appendTo(weatherDisplay)
+        weatherDisplay.append('<strong><span style="vertical-align:top;">:</span></strong>')
+        $.each(boostedTypes[weather.gameplay_weather], function (index, type) {
+            weatherDisplay.append(`
+                <img src='static/images/types/${type.toLowerCase()}.png' title=${i18n(type)} width=16 />
+            `)
+        })
+        if (!isUpToDateWeather(weather)) {
+            weatherDisplay.append(`
+                <br/><span class='weather-outdated'>(${i18n('outdated')})</span>
+            `)
+        }
+        weatherDisplay = weatherDisplay.prop('outerHTML')
+    }
+
     return `
         <div>
           <div id='gym-container'>
@@ -429,12 +452,13 @@ function gymLabel(gym) {
               <div class='team ${teamName.toLowerCase()}'>
                 <strong>${i18n(teamName)}</strong>
               </div>
+              ${weatherDisplay}
             </div>
             <div id='gym-container-right'>
               <div class='title'>
                 ${titleText} ${exDisplay}
               </div>
-              <div class='info-container'>
+              <div class='info-container wsnowrap'>
                 ${strenghtDisplay}
                 <div>
                   ${i18n('Free slots')}: <strong>${gym.slots_available}</strong>

--- a/static/js/map/map.gym.js
+++ b/static/js/map/map.gym.js
@@ -285,6 +285,7 @@ function gymLabel(gym) {
     var strenghtDisplay = ''
     var gymLeaderDisplay = ''
     var raidDisplay = ''
+    var weatherDisplay = ''
 
     if (gym.is_ex_raid_eligible) {
         exDisplay = '<img id="ex-icon" src="static/images/gym/ex.png" width="22" title="EX eligible Gym">'

--- a/static/sass/layout/_gym.scss
+++ b/static/sass/layout/_gym.scss
@@ -97,3 +97,7 @@
 .raid-level-6 {
   color: rgb(141, 54, 40);
 }
+
+.wsnowrap {
+  white-space: nowrap;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a weather icon and the associated boosted types underneath the gym's image.  This is a convenient way to see if a raid boss is boosted or not.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a convenient way to see if a raid boss is boosted or not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run this change on my server for weeks and it works fine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
