### PR TITLE
put missing asset filename in log message

### DIFF
--- a/rocketmad/dyn_img.py
+++ b/rocketmad/dyn_img.py
@@ -478,8 +478,8 @@ class ImageGenerator:
         if asset_path.exists():
             return asset_path, target_dir / target_filename
         else:
-            log.warning("Cannot find PogoAssets file for target file {}"
-                        .format(target_filename))
+            log.warning("Cannot find PogoAssets {} file for target file {}"
+                        .format(asset_path, target_filename))
             dummy_icon = self.pokemon_icon_path / 'pokemon_icon_000.png'
             target = Path(target_dir) / 'pm0.png'
             if dummy_icon.exists():


### PR DESCRIPTION
Im searching for the filename of the asset file for the warning message "[ WARNING] Cannot find PogoAssets file for target file pm25_g2_f598_c49.png" in the logfile.

## Description
Add the asset_path in the message

## Motivation and Context
For another icon pack with different filenames it is difficult to find the correct filename

## How Has This Been Tested?
My own prod server 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
