### PR TITLE
Restored steel type in invasion file and Rainy Lure check by default.

### DIFF
--- a/static/data/invasions.json
+++ b/static/data/invasions.json
@@ -359,11 +359,11 @@
     "grunt": "Male"
   },
   "28": {
-    "type": "",
+    "type": "Steel",
     "grunt": "Female"
   },
   "29": {
-    "type": "",
+    "type": "Steel",
     "grunt": "Male"
   },
   "30": {

--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -304,7 +304,7 @@ const StoreOptions = {
         type: StoreTypes.Set
     },
     includedLureTypes: {
-        default: [501, 502, 503, 504],
+        default: [501, 502, 503, 504, 505],
         type: StoreTypes.JSON
     },
     pokestopNotifs: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Restored steel type in Rocket Invasion Fields 28 and 29. Included in the Lure filter Rainy Lure that was unchecked by default.

## Motivation and Context
When filtering the types of Rocket invasion, the Steel field was once again without "Steel", showing only the invader's gender. When checking the history of the file "invasions.json" I found that this error occurred in November 2021 and since then no one has fixed it.

Also, it has always bothered me that it is not checked by default to display Rainy-type Lures in RocketMad and that I have to check it manually. 

## How Has This Been Tested?
Tested without any problems on my server, working perfectly on smartphones and computers. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
