### PR TITLE
Add all of Alola to filters

### DIFF
--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -14,7 +14,7 @@ const rarityNames = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Ultra Rare', 'N
 // FontAwesome gender classes.
 const genderClasses = ['fa-mars', 'fa-venus', 'fa-neuter']
 var pokemonSearchList = []
-const availablePokemonCount = 721
+const availablePokemonCount = 807
 const pokemonIds = new Set()
 
 function initPokemonData() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change to add all of Alola to the filters for pokemon/raids etc

## Description
Not much more to say pretty simple change

## Motivation and Context
Alola is missing from all current filters

## How Has This Been Tested?
In my environment

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
