### PR TITLE
Improve mobile menu & general layout

### DIFF
--- a/static/sass/layout/_pokemon-history.scss
+++ b/static/sass/layout/_pokemon-history.scss
@@ -1,8 +1,12 @@
 #pokemon-history-container {
-  padding-bottom: 16px;
+  padding: 16px;
 
   @media screen and (min-width: 601px) {
     padding: 0 19px 16px 19px;
+  }
+
+  table.dataTable>tbody>tr.child ul.dtr-details {
+    width: 100%;
   }
 }
 

--- a/static/sass/layout/_quest.scss
+++ b/static/sass/layout/_quest.scss
@@ -1,5 +1,5 @@
 #quest-container {
-  padding-bottom: 16px;
+  padding: 16px;
 
   @media screen and (min-width: 601px) {
     padding: 0 19px 16px 19px;
@@ -7,6 +7,10 @@
 
   #quest-title {
     margin-bottom: 0.8rem;
+  }
+
+  table.dataTable>tbody>tr.child ul.dtr-details {
+    width: 100%;
   }
 }
 

--- a/static/sass/layout/_sidenav.scss
+++ b/static/sass/layout/_sidenav.scss
@@ -3,6 +3,11 @@
   max-width: 80%;
   height: 100%;
   z-index: 1001;
+  margin-top: 56px;
+
+  @media screen and (max-width: 600px) {
+    margin-top: 48px;
+  }
 
   .sidenav-close {
     position: absolute;
@@ -16,7 +21,7 @@
   }
 
   li.active .collapsible-header {
-      border-bottom: 0 !important;
+    border-bottom: 0 !important;
   }
 
   .settings-container {
@@ -69,13 +74,6 @@
       line-height: 1;
       margin-right: 0;
     }
-  }
-}
-
-.map-body .sidenav {
-  @media screen and (min-width: 601px) {
-    top: 56px;
-    height: calc(100% - 56px);
   }
 }
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -117,12 +117,15 @@
       <li><a href="{{ url_for('pokemon_history_page') }}"><i class="material-icons">pets</i>{{ i18n('Pokémon history') }}</a></li>
       {% endif %}
       {% if quest_page %}
+      <li class="divider" tabindex="-1"></li>
       <li><a href="{{ url_for('quest_page') }}"><i class="material-icons">explore</i>{{ i18n('Quests') }}</a></li>
       {% endif %}
       {% if admin %}
+      <li class="divider" tabindex="-1"></li>
       <li><a href="{{ url_for('admin_page') }}"><i class="material-icons">dashboard</i>Admin</a></li>
       {% endif %}
       {% if madmin_url %}
+      <li class="divider" tabindex="-1"></li>
       <li><a href="{{ madmin_url }}" target="_blank"><i class="material-icons">phone_android</i>MADmin</a></li>
       {% endif %}
       {% if donate_url or patreon_url %}


### PR DESCRIPTION
## Description
- Move menu on mobile down below header bar
- Adjust mobile layout on some pages (e.g. pkm history)
- Add more dividers to drop down menu in header bar

_See screenshots for comparison._

## Motivation and Context
As the menu as well as some other pages look quite bad on mobile, I have adjusted some styling rules.

## How Has This Been Tested?
Own instance on mobile phone as well as on Chrome Dev tools.

## Screenshots (if appropriate):
Before
![Bildschirmfoto 2022-03-11 um 12 38 09](https://user-images.githubusercontent.com/727517/157937732-d9abff3a-a1f1-4d59-897b-8b504f9240fe.png)
After
![Bildschirmfoto 2022-03-11 um 12 37 34](https://user-images.githubusercontent.com/727517/157937786-9bac1479-6028-41f4-8675-f06204147245.png)


Before
![Bildschirmfoto 2022-03-11 um 12 40 00](https://user-images.githubusercontent.com/727517/157938347-7967d007-9bfd-4373-ab4f-4863800cf9dd.png)

After
![Bildschirmfoto 2022-03-11 um 12 39 27](https://user-images.githubusercontent.com/727517/157938428-5de2a975-1b3a-4ae7-82ce-412f5ca95965.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
