### PR TITLE
Add option to store and save settings in localstorage

### DIFF
--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -1401,7 +1401,7 @@ function initSettingsSidebar() {
 
     $('#save-settings-button').on('click', function () {
         const settingsName = prompt('Please state a name for this set of settings (saved settings with the same name will be overwritten):', 'Setting1')
-        settings.savedSettings[settingsName.replaceAll(/[^\w-_\ ]/gi, '')] = JSON.stringify(Store.dump())
+        settings.savedSettings[settingsName.replaceAll(/[^\w-_ ]/gi, '')] = JSON.stringify(Store.dump())
         Store.set('savedSettings', settings.savedSettings)
         refreshSavedSettings()
     })
@@ -1655,7 +1655,7 @@ function initSettingsSidebar() {
 const refreshSavedSettings = function () {
     const loadSettingsSelect = document.getElementById('load-settings-select')
     const deleteSettingsSelect = document.getElementById('delete-settings-select')
-    const addOption = function(item) {
+    const addOption = function (item) {
         const option = document.createElement('option')
         option.value = option.text = item
         loadSettingsSelect.options.add(option.cloneNode(true))

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -502,7 +502,7 @@ function initSettingsSidebar() {
             const oldGymLastScannedHours = settings.gymLastScannedHours
             settings.gymLastScannedHours = this.value
             if ((settings.gymLastScannedHours < oldGymLastScannedHours &&
-                !settings.gymLastScannedHours === 0) || oldGymLastScannedHours === 0) {
+                    !settings.gymLastScannedHours === 0) || oldGymLastScannedHours === 0) {
                 updateGyms()
             } else {
                 updateMap({ loadAllGyms: true })
@@ -1074,7 +1074,7 @@ function initSettingsSidebar() {
             }
 
             if ((settings.minNotifIvs < oldMinIvs || settings.maxNotifIvs > oldMaxIvs) &&
-                (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
+                    (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
                 updateMap({ loadAllPokemon: true })
             }
             updatePokemons(new Set(), true)
@@ -1109,7 +1109,7 @@ function initSettingsSidebar() {
             $('#pokemon-level-notifs-slider-title').text(`${i18n('Notif Levels')} (${settings.minNotifLevel} - ${settings.maxNotifLevel})`)
 
             if ((settings.minNotifLevel < oldMinLevel || settings.maxNotifLevel > oldMaxLevel) &&
-                (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
+                    (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
                 updateMap({ loadAllPokemon: true })
             }
             updatePokemons(new Set(), true)
@@ -1144,7 +1144,7 @@ function initSettingsSidebar() {
             const oldNotifRarities = settings.notifRarities
             settings.notifRarities = $(this).val().map(Number)
             if (settings.notifRarities.length > oldNotifRarities.length &&
-                (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
+                    (settings.showNotifPokemonOnly || settings.showNotifPokemonAlways)) {
                 updateMap({ loadAllPokemon: true })
             }
             updatePokemons()

--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -521,14 +521,14 @@ const Store = {
     },
     dump: function () {
         const dump = {}
-        for (let key in StoreOptions) {
+        for (const key in StoreOptions) {
             if (key === 'savedSettings') continue
             dump[key] = Store.get(key)
         }
         return dump
     },
-    restore: function(dump) {
-        for (let key in dump) {
+    restore: function (dump) {
+        for (const key in dump) {
             Store.set(key, dump[key])
         }
     }

--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -486,34 +486,50 @@ const StoreOptions = {
     zoomLevel: {
         default: 16,
         type: StoreTypes.Number
+    },
+    savedSettings: {
+        default: {},
+        type: StoreTypes.JSON
     }
 }
 
 const Store = {
     getOption: function (key) {
-        var option = StoreOptions[key]
+        const option = StoreOptions[key]
         if (!option) {
             throw new Error('Store key was not defined ' + key)
         }
         return option
     },
     get: function (key) {
-        var option = this.getOption(key)
-        var optionType = option.type
-        var rawValue = localStorage[key]
+        const option = this.getOption(key)
+        const optionType = option.type
+        const rawValue = localStorage[key]
         if (rawValue === null || rawValue === undefined) {
             return option.default
         }
-        var value = optionType.parse(rawValue)
-        return value
+        return optionType.parse(rawValue)
     },
     set: function (key, value) {
-        var option = this.getOption(key)
-        var optionType = option.type || StoreTypes.String
-        var rawValue = optionType.stringify(value)
+        const option = this.getOption(key)
+        const optionType = option.type || StoreTypes.String
+        const rawValue = optionType.stringify(value)
         localStorage[key] = rawValue
     },
     reset: function (key) {
         localStorage.removeItem(key)
+    },
+    dump: function () {
+        const dump = {}
+        for (let key in StoreOptions) {
+            if (key === 'savedSettings') continue
+            dump[key] = Store.get(key)
+        }
+        return dump
+    },
+    restore: function(dump) {
+        for (let key in dump) {
+            Store.set(key, dump[key])
+        }
     }
 }

--- a/templates/map.html
+++ b/templates/map.html
@@ -1601,6 +1601,27 @@
         <div class="collapsible-body">
           <div class="settings-container">
             <div class="form-control">
+              <div><a id="save-settings-button" class="waves-effect waves-light btn"><i class="material-icons left">settings_backup_restore</i>{{ i18n('Save current settings') }}</a></div>
+            </div>
+            <div class="form-control">
+              <div class="input-field">
+                <div class="select-title">{{ i18n('Load saved settings') }}</div>
+                <select id="load-settings-select">
+                  <!-- Options are dynamically added. -->
+                </select>
+              </div>
+            </div>
+            <div class="form-control">
+              <div class="input-field">
+                <div class="select-title">{{ i18n('Delete saved settings') }}</div>
+                <select id="delete-settings-select">
+                  <!-- Options are dynamically added. -->
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="settings-container">
+            <div class="form-control">
               <input id="settings-file-input" type="file" accept=".txt" style="display:none;">
               <div><a id="import-settings-button" class="waves-effect waves-light btn" onclick="document.getElementById('settings-file-input').click()"><i class="material-icons left">file_download</i>{{ i18n('Import settings') }}</a></div>
             </div>


### PR DESCRIPTION
## Description
This PR adds the option to store the current user's settings in a named entry in the local storage.
The saved settings can later be restored or deleted.

_Note: resetting all settings will also erase all saved settings_

## Motivation and Context
This features enables easily switch between multiple setting scenarios (e.g. only quests, only pkm), which before would have required a lot of setting changes by the user. 

## How Has This Been Tested?
Own instance.

## Screenshots (if appropriate):
![Bildschirmfoto 2022-03-11 um 20 32 23](https://user-images.githubusercontent.com/727517/157942163-929687d0-b81e-4e3f-9f26-e622cf32c532.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
