### PR TITLE
Enable filters when element is excluded

### DIFF
--- a/static/js/map/map.gym.js
+++ b/static/js/map/map.gym.js
@@ -660,6 +660,7 @@ function excludeRaidLevel(level) { // eslint-disable-line no-unused-vars
 function excludeRaidPokemon(id) { // eslint-disable-line no-unused-vars
     if (filterManagers.excludedRaidPokemon !== null) {
         filterManagers.excludedRaidPokemon.add([id])
+        $('#filter-raid-pokemon-switch').prop('checked', true).trigger('change')
     }
 }
 

--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -474,6 +474,7 @@ function getExcludedPokemon() {
 function excludePokemon(id) { // eslint-disable-line no-unused-vars
     if (filterManagers.excludedPokemon !== null) {
         filterManagers.excludedPokemon.add([id])
+        $('#filter-pokemon-switch').prop('checked', true).trigger('change')
     }
 }
 

--- a/static/js/map/map.pokestop.js
+++ b/static/js/map/map.pokestop.js
@@ -543,18 +543,21 @@ function removePokestopMarker(id) { // eslint-disable-line no-unused-vars
 function excludeQuestPokemon(id) { // eslint-disable-line no-unused-vars
     if (filterManagers.excludedQuestPokemon !== null) {
         filterManagers.excludedQuestPokemon.add([id])
+        $('#filter-quests-switch').prop('checked', true).trigger('change')
     }
 }
 
 function excludeQuestItem(id, bundle) { // eslint-disable-line no-unused-vars
     if (filterManagers.excludedQuestItems !== null) {
         filterManagers.excludedQuestItems.add([id + '_' + bundle])
+        $('#filter-quests-switch').prop('checked', true).trigger('change')
     }
 }
 
 function excludeInvasion(id) { // eslint-disable-line no-unused-vars
     if (filterManagers.excludedInvasions !== null) {
         filterManagers.excludedInvasions.add([id])
+        $('#filter-invasions-switch').prop('checked', true).trigger('change')
     }
 }
 


### PR DESCRIPTION
## Description
When a users hides an element the corresponding filter switch is enabled.

Basically solves the same issue as stated in #197 but uses a bit of a different approach.

Happy to close this in favor of another solution.

## Motivation and Context
Exclude options on tool tips are not working when filtering is not activated.

## How Has This Been Tested?
Own Instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
