### PR TITLE
Improve Filter Dialog (especially) on Mobile

### DIFF
--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -1744,15 +1744,34 @@ class FilterManager {
         const modalDiv = document.getElementById(modalId)
         this._settingsIds = settings[settingsKey]
         this._titleElement = modalDiv.querySelector(this.getTitleSelector())
-        this._buttonById = {}
+        this._filterListDiv = modalDiv.querySelector(this.getListSelector())
+        this._buttonById = { }
         this._modalInitialized = false
+
+        const appendButtons = (start, end) => {
+            if (start > 0) this._filterListDiv.lastChild.remove()
+            const buttons = Object.values(this._buttonById)
+            this._filterListDiv.append(...buttons.slice(start, end))
+            if (end < buttons.length) {
+                const loadMoreButton = document.createElement('div')
+                loadMoreButton.classList.add('load-more-button')
+                loadMoreButton.innerHTML = 'Load More...'
+                loadMoreButton.addEventListener('click', () => {
+                    appendButtons(end, end + 100)
+                })
+                this._filterListDiv.appendChild(loadMoreButton)
+            }
+        }
+
+        setModalFunction(modalDiv, 'onCloseEnd', () => {
+            this._filterListDiv.innerHTML = ''
+        })
 
         setModalFunction(modalDiv, 'onOpenStart', () => {
             if (this._modalInitialized) {
+                appendButtons(0, 100)
                 return
             }
-
-            const filterListDiv = modalDiv.querySelector(this.getListSelector())
 
             for (const id of this.getAllIds()) {
                 const isActive = this._settingsIds.has(id) !== isExclusion
@@ -1764,12 +1783,13 @@ class FilterManager {
                     isActive
                 )
                 this._buttonById[id] = button
-                filterListDiv.appendChild(button)
             }
+
+            appendButtons(0, 100)
 
             this._updateTitle()
 
-            filterListDiv.addEventListener('click', e => {
+            this._filterListDiv.addEventListener('click', e => {
                 const button = e.target.closest('.filter-button')
                 if (button === null) {
                     return
@@ -1801,8 +1821,8 @@ class FilterManager {
                 }
             }
 
-            filterListDiv.parentElement.querySelector('.filter-select-all').addEventListener('click', onSelectDeselectAllClick.bind(this, true))
-            filterListDiv.parentElement.querySelector('.filter-deselect-all').addEventListener('click', onSelectDeselectAllClick.bind(this, false))
+            this._filterListDiv.parentElement.querySelector('.filter-select-all').addEventListener('click', onSelectDeselectAllClick.bind(this, true))
+            this._filterListDiv.parentElement.querySelector('.filter-deselect-all').addEventListener('click', onSelectDeselectAllClick.bind(this, false))
 
             this._modalInitialized = true
         })

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -1681,46 +1681,24 @@ const refreshSavedSettings = function () {
 
 const createFilterButton = (function () {
     let templateDiv
-    let lazyImageObserver
 
     function createTemplateDiv() {
         const containerDiv = document.createElement('div')
         containerDiv.innerHTML = `
-          <div class='filter-button'>
-            <div class='filter-button-content'>
-              <div id='btnheader'></div>
-              <div><div class='filter-image'></div>
-              <div id='btnfooter'></div>
+          <div class="filter-button">
+            <div class="filter-button-content">
+              <div id="btnheader"></div>
+              <img class="filter-image" src="../../images/placeholder.png" loading="lazy">
+              <div id="btnfooter"></div>
             </div>
           </div>`
         return containerDiv.firstElementChild
-    }
-
-    function tryCreateLazyImageObserver() {
-        if (!('IntersectionObserver' in window)) {
-            return null
-        }
-
-        return new IntersectionObserver(function (entries, observer) {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    const lazyImage = entry.target
-                    lazyImage.style.content = lazyImage.dataset.lazyContent
-                    delete lazyImage.dataset.lazyContent
-                    observer.unobserve(lazyImage)
-                }
-            })
-        })
     }
 
     return function (id, header, footer, iconUrl, isActive) {
         if (typeof templateDiv === 'undefined') {
             templateDiv = createTemplateDiv()
         }
-        if (typeof lazyImageObserver === 'undefined') {
-            lazyImageObserver = tryCreateLazyImageObserver()
-        }
-
         // Clone a template div, which is faster than creating and parsing HTML for each filter button.
         const buttonDiv = templateDiv.cloneNode(true)
         buttonDiv.dataset.id = id
@@ -1732,14 +1710,8 @@ const createFilterButton = (function () {
         headerDiv.removeAttribute('id')
         headerDiv.textContent = header
 
-        const imageDiv = buttonDiv.querySelector('div.filter-image')
-        const imageContent = `url(${iconUrl})`
-        if (lazyImageObserver === null) {
-            imageDiv.style.content = imageContent
-        } else {
-            imageDiv.dataset.lazyContent = imageContent
-            lazyImageObserver.observe(imageDiv)
-        }
+        const imageImg = buttonDiv.querySelector('img.filter-image')
+        imageImg.setAttribute('src', iconUrl)
 
         const footerDiv = buttonDiv.querySelector('#btnfooter')
         footerDiv.removeAttribute('id')

--- a/static/sass/components/_modal.scss
+++ b/static/sass/components/_modal.scss
@@ -86,7 +86,7 @@
       height: 2rem;
   }
 
-  .filter-button {
+  .filter-button, .load-more-button {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -108,6 +108,10 @@
       height: 32px;
       margin: auto;
     }
+  }
+
+  .load-more-button {
+    background-color: #cddfff;
   }
 
   .filter-button-content {
@@ -135,6 +139,11 @@
     &.active {
       background-color: #004d40;
     }
+  }
+
+  .load-more-button {
+    color: $text-color-dark;
+    background-color: #1c40b7;
   }
 
   .btn-flat {

--- a/static/sass/components/_modal.scss
+++ b/static/sass/components/_modal.scss
@@ -107,7 +107,6 @@
       width: 32px;
       height: 32px;
       margin: auto;
-      content: url(../../images/placeholder.png);
     }
   }
 


### PR DESCRIPTION
## Description
This PR improves the responsiveness of the filter modal on mobile browsers by only partially displaying mons in chunks of 100. The user can load the next chunks by pressing the new "Load More..." button.

Furthermore, I have changed the former approach of using the `IntersectionObserver` to plain lazy loading of images.

**Hint:** Unfortunately, this partially breaks the search functionality as only displayed items are searchable.

## Motivation and Context
Currently, the huge amount of >800 mons and the corresponding amount of html nodes freezes mobile browsers when the filter dialog is opened.

## How Has This Been Tested?
Own instance on desktop (OSX) and mobile (Android) Chrome.

## Screenshots (if appropriate):
![Bildschirmfoto 2022-03-18 um 21 46 55](https://user-images.githubusercontent.com/727517/159080961-a511c004-c82b-4686-8fae-99f8019e9e2f.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.