### PR TITLE
Fix store dump for Set type

### DIFF
--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -523,7 +523,11 @@ const Store = {
         const dump = {}
         for (const key in StoreOptions) {
             if (key === 'savedSettings') continue
-            dump[key] = Store.get(key)
+            if (StoreOptions[key].type === StoreTypes.Set) {
+                dump[key] = Array.from(Store.get(key))
+            } else {
+                dump[key] = Store.get(key)
+            }
         }
         return dump
     },


### PR DESCRIPTION
## Description
Filter lists were not saved on "Save current settings".

## Motivation and Context
Filter lists on the map are stored as type `Set`, which seems to not be properly converted to string on `JSON.stringify`. This caused filter lists to be not saved on "Save current settings".
To fix this, those fields need to be converted first to `Array`.

## How Has This Been Tested?
Own instance with pokemon exclude and quest item exclude filters.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
