### PR TITLE
Add tier 7 support to egg stats table

### DIFF
--- a/static/js/map/map.stats.js
+++ b/static/js/map/map.stats.js
@@ -304,7 +304,7 @@ function updateStatsTable() {
 
     if (selectedTab === '#gym-stats-tab') {
         const teamCounts = [0, 0, 0, 0]
-        const eggCounts = [0, 0, 0, 0, 0, 0]
+        const eggCounts = [0, 0, 0, 0, 0, 0, 0]
         const raidPokemonData = {}
         let gymCount = 0
         let eggCount = 0


### PR DESCRIPTION
## Description
This change now lists the amount of the new eggs in the stats table.

## Screenshots (if appropriate):
![Egg Stats with new tier](https://user-images.githubusercontent.com/2234131/166425414-d18be8ce-a760-4cc9-bd4b-fb7c744d511e.jpg)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
