### PR TITLE
Update Portuguese translation and Raid Level 9 check by default

### DIFF
--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -276,7 +276,7 @@ const StoreOptions = {
         type: StoreTypes.Boolean
     },
     includedRaidLevels: {
-        default: [1, 2, 3, 4, 5, 6, 7, 8],
+        default: [1, 2, 3, 4, 5, 6, 7, 8, 9],
         type: StoreTypes.JSON
     },
     raidNotifs: {

--- a/static/locales/pt_br.json
+++ b/static/locales/pt_br.json
@@ -834,6 +834,7 @@
   "Level 6": "Nível 6",
   "Level 7": "Nível 7",
   "Level 8": "Nível 8",
+  "Level 9": "Nível 9",
   "Levels": "Níveis",
   "Load saved settings": "Carregar configurações salvas",
   "Delete saved settings" : "Excluir configurações salvas",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New text for Portuguese  and included in the Raid filter Level 9 that was unchecked by default.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Update the Portuguese translation with the new text and raid filter fix
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested without any problems on my server, working perfectly on smartphones and computers.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
