### PR TITLE
Add npm run invasions for updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "build": "grunt build",
     "watch": "grunt default",
     "lint": "grunt lint",
-    "grunt": "grunt"
+    "grunt": "grunt",
+    "invasions": "grunt invasions"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Run python from npm script, copy invasions.json to static/data and run build to use it.
You can still use normal python script and copy it yourself, but one copy-paste command seems like easier thing to do.

## Motivation and Context
Questions on Discord.

## How Has This Been Tested?
works here.


## Screenshots (if appropriate):
Broken flow:
```
rocketmad@mad:~/RM$ npm run invasions

> rocketmad@1.0.0 invasions
> grunt invasions

Running "gen_invasions" task
Running python3 scripts/generate_invasion_data.py - this could take a minute
>> Traceback (most recent call last):
>>   File "/home/rocketmad/RM/scripts/generate_invasion_data.py", line 1, in <module>
>>     from pogodata import PogoData
>> ModuleNotFoundError: No module named 'pogodata'
--
>> Detected ModuleNotFoundError - you sure you run it via correct python/venv?
>> You can provider proper python3 executable via --python option, for example:
>> npm run invasions -- --python=~/venv/bin/python3
Warning: Task "gen_invasions" failed. Use --force to continue.

Aborted due to warnings.
```

Working flow:
```
rocketmad@mad:~/RM$ npm run invasions -- --python=~/venv/bin/python3
[or activate venv first]
rocketmad@mad:~/RM$ source ~/venv/bin/activate
(venv) rocketmad@mad:~/RM$ npm run invasions

> rocketmad@1.0.0 invasions
> grunt invasions "--python=~/venv/bin/python3"

Running "gen_invasions" task
Running ~/venv/bin/python3 scripts/generate_invasion_data.py - this could take a minute
Copying generated file to static/data/invasions.json
Running "clean:0" (clean) task
>> 1 path cleaned.

Running "clean:1" (clean) task
>> 5 paths cleaned.

Running "clean:2" (clean) task
>> 1 path cleaned.

Running "clean:3" (clean) task
>> 1 path cleaned.

Running "newer:concat:dist1" (newer) task

Running "concat:dist1" (concat) task
(... blablabla ...)
✔ grunt-jsonmin completed successfully

Running "newer-postrun:jsonmin:build:12:/home/rocketmad/RM/node_modules/grunt-newer/.cache" (newer-postrun) task

Running "unzip:static01" (unzip) task
No files were found in source. "static/" has not been created.

Done.
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
