### PR TITLE
Settings panel translation support

### DIFF
--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -1513,7 +1513,7 @@ function initSettingsSidebar() {
 
     $('#settings-file-input').on('change', function () {
         function loaded(e) {
-            const confirmed = confirm('Are you sure you want to import settings?')
+            const confirmed = confirm(i18n('Are you sure you want to import settings?'))
             if (!confirmed) {
                 return
             }
@@ -1538,7 +1538,7 @@ function initSettingsSidebar() {
     })
 
     $('#load-settings-select').on('change', function () {
-        const confirmed = confirm(`Are you sure you want to load the saved settings "${this.value}" and replace all current ones?`)
+        const confirmed = confirm(`${i18n('Are you sure you want to load the saved settings')} "${this.value}" ${i18n('and replace all current ones?')}`)
         if (confirmed) {
             Store.restore(JSON.parse(settings.savedSettings[this.value]))
             window.location.reload()
@@ -1546,7 +1546,7 @@ function initSettingsSidebar() {
     })
 
     $('#delete-settings-select').on('change', function () {
-        const confirmed = confirm(`Are you sure you want to delete the saved settings named "${this.value}"?`)
+        const confirmed = confirm(`${i18n('Are you sure you want to delete the saved settings named')} "${this.value}"?`)
         if (confirmed) {
             delete settings.savedSettings[this.value]
             Store.set('savedSettings', settings.savedSettings)
@@ -1555,7 +1555,7 @@ function initSettingsSidebar() {
     })
 
     $('#save-settings-button').on('click', function () {
-        const settingsName = prompt('Please state a name for this set of settings (saved settings with the same name will be overwritten):', 'Setting1')
+        const settingsName = prompt(i18n('Please state a name for this set of settings (saved settings with the same name will be overwritten):'), 'Setting1')
         settings.savedSettings[settingsName.replaceAll(/[^\w-_ ]/gi, '')] = JSON.stringify(Store.dump())
         Store.set('savedSettings', settings.savedSettings)
         refreshSavedSettings()
@@ -1566,7 +1566,7 @@ function initSettingsSidebar() {
     })
 
     $('#reset-settings-button').on('click', function () {
-        const confirmed = confirm('Are you sure you want to reset all settings to default values?')
+        const confirmed = confirm(i18n('Are you sure you want to reset all settings to default values?'))
         if (confirmed) {
             localStorage.clear()
             window.location.reload()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Settings translation support
## Description
<!--- Describe your changes in detail -->
I added translation support for settings in the left panel i18n()
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It enables the translation possibility of the settings on the left panel

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
It's working perfectly on my environnement.
<!--- Include details of your testing environment, and the tests you ran to -->
Npm run build passed successfuly and map is running fine

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
