### PR TITLE
add DB unix socket support

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -124,11 +124,12 @@
 # Database settings
 ###################
 
-#db-host:                       # Required for mysql ()
-#db-name:                       # Required for mysql
-#db-user:                       # Required for mysql
-#db-pass:                       # Required for mysql
-#db-port:                       # Required for mysql (default=3306)
+#db-host:                       # Hostname or IP address for mysql database (default=127.0.0.1)
+#db-port:                       # Port to connect to mysql database (default=3306)
+#db-socket:                     # Path to a unix socket file (disabled by default)
+#db-name:                       # Mysql database name
+#db-user:                       # Mysql user name
+#db-pass:                       # Mysql password
 #db-pool-recycle:               # Number of seconds after which a connection is automatically recycled. (default=7200)
 
 

--- a/rocketmad/app.py
+++ b/rocketmad/app.py
@@ -129,7 +129,11 @@ def create_app():
     if args.cors:
         CORS(app)
 
-    db_uri = 'mysql+pymysql://{}:{}@{}:{}/{}?charset=utf8mb4'.format(
+    if args.db_socket:
+        db_uri = 'mysql+pymysql:///{}?charset=utf8mb4&unix_socket={}'.format(
+        args.db_name, args.db_socket)
+    else:
+        db_uri = 'mysql+pymysql://{}:{}@{}:{}/{}?charset=utf8mb4'.format(
         args.db_user, args.db_pass, args.db_host, args.db_port, args.db_name)
     app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
     app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {

--- a/rocketmad/utils.py
+++ b/rocketmad/utils.py
@@ -359,14 +359,16 @@ def get_args(access_config=None):
     group.add_argument('--db-name',
                        help='Name of the database to be used.', required=True)
     group.add_argument('--db-user',
-                       help='Username for the database.', required=True)
+                       help='Username for the database.')
     group.add_argument('--db-pass',
-                       help='Password for the database.', required=True)
+                       help='Password for the database.')
     group.add_argument('--db-host',
                        help='IP or hostname for the database.',
                        default='127.0.0.1')
     group.add_argument('--db-port',
                        help='Port for the database.', type=int, default=3306)
+    group.add_argument('--db-socket',
+                       help='Path to a unix socket file, disabled by default')
     group.add_argument('--db-pool-recycle',
                        type=int, default=7200,
                        help='Number of seconds after which a connection is '

--- a/runserver.py
+++ b/runserver.py
@@ -84,8 +84,8 @@ def validate_assets(args):
 
 
 def startup_db(clear_db):
-    log.info('Connecting to MySQL database on %s:%i...',
-             args.db_host, args.db_port)
+    connection_str = f"{args.db_host}:{args.db_port}" if not args.db_socket else args.db_socket
+    log.info(f'Connecting to MySQL database on {connection_str}...')
 
     if clear_db:
         log.info('Clearing RocketMAD tables')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the support of unix sockets when connecting to mysql.

## How Has This Been Tested?
Tested connecting to a socket and to a ip/hostname successfully. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
