### PR TITLE
Update utils.pokemon.js to include Gen 8 and 9

### DIFF
--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -17,7 +17,7 @@ const rarityNames = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Ultra Rare', 'N
 // FontAwesome gender classes.
 const genderClasses = ['fa-mars', 'fa-venus', 'fa-neuter']
 var pokemonSearchList = []
-const availablePokemonCount = 809
+const availablePokemonCount = 1010
 const pokemonIds = new Set()
 
 function initPokemonData() {
@@ -45,6 +45,8 @@ function initPokemonData() {
                 gen = 7
             } else if (id <= 898) {
                 gen = 8
+            } else if (id <= 1010) {
+                gen = 9
             }
             pokemonData[id].gen = gen
             pokemonSearchList.push({
@@ -85,19 +87,6 @@ function getPokemonIds() {
         for (let i = 1; i <= availablePokemonCount; i++) {
             pokemonIds.add(i)
         }
-        // Gen 8.
-        pokemonIds.add(819)
-        pokemonIds.add(820)
-        pokemonIds.add(831)
-        pokemonIds.add(832)
-        pokemonIds.add(862)
-        pokemonIds.add(863)
-        pokemonIds.add(865)
-        pokemonIds.add(866)
-        pokemonIds.add(867)
-        pokemonIds.add(870)
-        pokemonIds.add(888)
-        pokemonIds.add(889)
     }
     return new Set(pokemonIds)
 }


### PR DESCRIPTION
## Description
Includes all Pokemon up to 1010 to filter selection.

Some released Pokemon were already missing.
IDS: 893,894,895,900,901,903,904,999,1000

## Motivation and Context
Niantic releases Pokemon from all gens now,
so make em all available instead of whitelisting.

If your pogo_assets are up to date,
user sees dummy doll icon = not released.

## How Has This Been Tested?
On my local install with latest pogo_assets.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
