### PR TITLE
Add detailed invasion stats in the sidebar (async)

### DIFF
--- a/static/js/map/map.stats.js
+++ b/static/js/map/map.stats.js
@@ -429,7 +429,7 @@ function updateStatsTable() {
     if (selectedTab === '#pokestop-stats-tab') {
         let noStatusCount = 0
         let questCount = 0
-        let invasionCount = 0
+        let invasionCounts = {}
         let normalLureCount = 0
         let glacialLureCount = 0
         let magneticLureCount = 0
@@ -448,7 +448,15 @@ function updateStatsTable() {
                     hasStatus = true
                 }
                 if (isPokestopMeetsInvasionFilters(pokestop)) {
-                    invasionCount++
+                    if ( !(pokestop.incident_grunt_type in invasionCounts) ) {
+                        let invDesc = 'Unknown Invasion'
+                        if (pokestop.incident_grunt_type != 0) {
+                            invDesc = `${getInvasionType(pokestop.incident_grunt_type)} ${getInvasionGrunt(pokestop.incident_grunt_type)}`
+                        }
+                        invasionCounts[pokestop.incident_grunt_type] = [1, getPokestopIconUrl(pokestop), invDesc]
+                    } else {
+                        invasionCounts[pokestop.incident_grunt_type][0] += 1
+                    }
                     hasStatus = true
                 }
                 if (isPokestopMeetsLureFilters(pokestop)) {
@@ -501,13 +509,13 @@ function updateStatsTable() {
                 ]
             )
         }
-        if (invasionCount > 0) {
+        for (invNum in invasionCounts) {
             pokestopRows.push(
                 [
-                    '<img src="static/images/pokestop/stop_i.png" width=32 />',
-                    i18n('Rocket Invasion'),
-                    invasionCount,
-                    (invasionCount * 100) / pokestopCount
+                    `<img src="${invasionCounts[invNum][1]}" width=32 />`,
+                    i18n(invasionCounts[invNum][2]),
+                    invasionCounts[invNum][0],
+                    (invasionCounts[invNum][0] * 100) / pokestopCount
                 ]
             )
         }

--- a/static/js/map/map.stats.js
+++ b/static/js/map/map.stats.js
@@ -509,7 +509,7 @@ function updateStatsTable() {
                 ]
             )
         }
-        for (invNum in invasionCounts) {
+        for (let invNum in invasionCounts) {
             pokestopRows.push(
                 [
                     `<img src="${invasionCounts[invNum][1]}" width=32 />`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR makes the pokestop sidebar more detailed in regard to incidents, separating out counts for each one, like kecleon, coin incidents, showcases, and each grunt/leader.

## Description
<!--- Describe your changes in detail -->
This counts each incident currently on the map (you can filter out ones you don't want to see) and lists them in the sidebar.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
