### PR TITLE
Update updateLabelDiffTime to include days left

### DIFF
--- a/static/js/map/map.pokestop.js
+++ b/static/js/map/map.pokestop.js
@@ -342,7 +342,7 @@ function pokestopLabel(pokestop) {
                   </div>
                 </div>
                 <div class='disappear'>
-                  ${timestampToTime(invasionExpireTime)} (<span class='label-countdown' disappears-at='${invasionExpireTime}'>00m00s</span>)
+                  ${timestampToDateTime(invasionExpireTime)} (<span class='label-countdown' disappears-at='${invasionExpireTime}'>00m00s</span>)
                 </div>
                 <div class='info-container'>
                   ${typeDisplay}

--- a/static/js/map/map.pokestop.js
+++ b/static/js/map/map.pokestop.js
@@ -342,7 +342,7 @@ function pokestopLabel(pokestop) {
                   </div>
                 </div>
                 <div class='disappear'>
-                  ${timestampToDateTime(invasionExpireTime)} (<span class='label-countdown' disappears-at='${invasionExpireTime}'>00m00s</span>)
+                  ${timestampToDateTime(invasionExpireTime)} (<span class='label-countdown' disappears-at='${invasionExpireTime}'>00h00m00s</span>)
                 </div>
                 <div class='info-container'>
                   ${typeDisplay}

--- a/static/js/map/map.pokestop.js
+++ b/static/js/map/map.pokestop.js
@@ -342,7 +342,7 @@ function pokestopLabel(pokestop) {
                   </div>
                 </div>
                 <div class='disappear'>
-                  ${timestampToDateTime(invasionExpireTime)} (<span class='label-countdown' disappears-at='${invasionExpireTime}'>00h00m00s</span>)
+                  ${timestampToTime(invasionExpireTime)} (<span class='label-countdown' disappears-at='${invasionExpireTime}'>00h00m00s</span>)
                 </div>
                 <div class='info-container'>
                   ${typeDisplay}

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -231,7 +231,7 @@ function updateLabelDiffTime() {
         if (disappearsAt.time < disappearsAt.now) {
             timestring = 'expired'
         } else if (days > 0) {
-            timestring = lpad(days, 2, 0) + 'd' + lpad(hours, 2, 0) + 'h' + lpad(minutes, 2, 0) + 'm'
+            timestring = days + 'd' + lpad(hours, 2, 0) + 'h' + lpad(minutes, 2, 0) + 'm'
         } else if (hours > 0) {
             timestring = lpad(hours, 2, 0) + 'h' + lpad(minutes, 2, 0) + 'm' + lpad(seconds, 2, 0) + 's'
         } else {

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -201,9 +201,11 @@ function getTimeUntil(time) {
     var sec = Math.floor((tdiff / 1000) % 60)
     var min = Math.floor((tdiff / 1000 / 60) % 60)
     var hour = Math.floor((tdiff / (1000 * 60 * 60)) % 24)
+    var day = Math.floor(tdiff / (1000 * 60 * 60 * 24))
 
     return {
         total: tdiff,
+        day: day,
         hour: hour,
         min: min,
         sec: sec,
@@ -220,6 +222,7 @@ function updateLabelDiffTime() {
     $('.label-countdown').each(function (index, element) {
         var disappearsAt = getTimeUntil(parseInt(element.getAttribute('disappears-at')))
 
+        var days = disappearsAt.day
         var hours = disappearsAt.hour
         var minutes = disappearsAt.min
         var seconds = disappearsAt.sec
@@ -227,6 +230,8 @@ function updateLabelDiffTime() {
 
         if (disappearsAt.time < disappearsAt.now) {
             timestring = 'expired'
+        } else if (days > 0) {
+            timestring = lpad(days, 2, 0) + 'd' + lpad(hours, 2, 0) + 'h' + lpad(minutes, 2, 0) + 'm'
         } else if (hours > 0) {
             timestring = lpad(hours, 2, 0) + 'h' + lpad(minutes, 2, 0) + 'm' + lpad(seconds, 2, 0) + 's'
         } else {


### PR DESCRIPTION
## Description
Added days to the remaining time calculations used in labels.

## Motivation and Context
Some timers like showcases and elite raids have longer diff times.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
