### PR TITLE
Add size display and filters to RM-async

### DIFF
--- a/rocketmad/models.py
+++ b/rocketmad/models.py
@@ -54,6 +54,7 @@ class Pokemon(db.Model):
     last_modified = db.Column(db.DateTime)
     seen_type = db.Column(db.String)
     fort_id = db.Column(db.String)
+    size = db.Column(db.SmallInteger)
 
     __table_args__ = (
         Index('pokemon_spawnpoint_id', 'spawnpoint_id'),
@@ -77,7 +78,8 @@ class Pokemon(db.Model):
             Pokemon.cp, Pokemon.cp_multiplier, Pokemon.weight, Pokemon.height,
             Pokemon.gender, Pokemon.form, Pokemon.costume,
             Pokemon.catch_prob_1, Pokemon.catch_prob_2, Pokemon.catch_prob_3,
-            Pokemon.weather_boosted_condition, Pokemon.last_modified, Pokemon.seen_type
+            Pokemon.weather_boosted_condition, Pokemon.last_modified, Pokemon.seen_type,
+            Pokemon.size
         ]
 
         if verified_despawn_time:

--- a/static/js/map/map.js
+++ b/static/js/map/map.js
@@ -150,7 +150,9 @@ const settings = {
     startLocationMarkerStyle: null,
     userLocationMarkerStyle: null,
     darkMode: null,
-    clusterZoomLevel: null
+    clusterZoomLevel: null,
+    filterPokemonBySize: null,
+    filterPokemonBySizeOptions: null
 }
 
 const notifiedPokemonData = {}

--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -5,7 +5,7 @@ pokemonNotifiedZIndex, pokemonRareZIndex, pokemonUltraRareZIndex,
 pokemonUncommonZIndex, pokemonVeryRareZIndex, pokemonZIndex, removeMarker,
 removeRangeCircle, sendNotification, settings, setupRangeCircle,
 updateRangeCircle, weatherClassesDay, weatherNames, updateMarkerLayer,
-createPokemonMarker, filterManagers, serverSettings
+createPokemonMarker, filterManagers, serverSettings, getSizeDisplay
 */
 /* exported processPokemon, updatePokemons */
 
@@ -52,6 +52,10 @@ function isPokemonMeetsFilters(pokemon, isNotifPokemon) {
             // Pokemon is not encountered.
             return false
         }
+    }
+
+    if (settings.filterPokemonBySize && settings.filterPokemonBySizeOptions && !settings.filterPokemonBySizeOptions.includes(pokemon.size)) {
+        return false
     }
 
     if (settings.excludeNearbyCells && pokemon.seen_type === 'nearby_cell') {
@@ -191,6 +195,7 @@ function pokemonLabel(item) {
     var cp = item.cp
     var cpMultiplier = item.cp_multiplier
     var weatherBoostedCondition = item.weather_boosted_condition
+    var size = getSizeDisplay(item.size)
 
     var pokemonIcon = getPokemonRawIconUrl(item, serverSettings.generateImages)
     var gen = getPokemonGen(id)
@@ -202,6 +207,7 @@ function pokemonLabel(item) {
     var verifiedDisplay = ''
     var typesDisplay = ''
     var statsDisplay = ''
+    var sizeDisplay = ''
     var nearbyStopWarning = ''
 
     if (id === 29 || id === 32) {
@@ -268,6 +274,14 @@ function pokemonLabel(item) {
                 </div>`
         }
 
+        if (size) {
+            sizeDisplay = `
+                <div>
+                    ${i18n('Size')}: <strong>${size}</strong>
+                </div>
+            `
+        }
+
         statsDisplay = `
             <div class='info-container'>
               <div>
@@ -286,6 +300,7 @@ function pokemonLabel(item) {
                 ${i18n('Weight')}: <strong>${weight}kg</strong> | ${i18n('Height')}: <strong>${height}m</strong>
               </div>
               ${catchRatesDisplay}
+              ${sizeDisplay}
             </div>`
 
         let rarityDisplay = ''

--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -261,8 +261,6 @@ function pokemonLabel(item) {
         var move2Name = getMoveName(item.move_2)
         var move1Type = getMoveTypeNoI8ln(item.move_1)
         var move2Type = getMoveTypeNoI8ln(item.move_2)
-        var weight = item.weight.toFixed(2)
-        var height = item.height.toFixed(2)
 
         var catchRatesDisplay = ''
         if (serverSettings.catchRates && item.catch_prob_1) {
@@ -295,9 +293,6 @@ function pokemonLabel(item) {
               </div>
               <div>
                ${i18n('Charge')}: <strong>${move2Name}</strong> <img class='move-type-icon' src='static/images/types/${move2Type.toLowerCase()}.png' title='${i18n(move2Type)}' width='15'>
-              </div>
-              <div>
-                ${i18n('Weight')}: <strong>${weight}kg</strong> | ${i18n('Height')}: <strong>${height}m</strong>
               </div>
               ${catchRatesDisplay}
               ${sizeDisplay}

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -28,6 +28,8 @@ function initSettings() {
     }
     if (serverSettings.pokemonValues) {
         settings.filterPokemonByValues = Store.get('filterPokemonByValues')
+        settings.filterPokemonBySize = Store.get('filterPokemonBySize')
+        settings.filterPokemonBySizeOptions = Store.get('filterPokemonBySizeOptions')
         settings.noFilterValuesPokemon = Store.get('noFilterValuesPokemon')
         settings.minIvs = Store.get('minIvs')
         settings.maxIvs = Store.get('maxIvs')
@@ -236,6 +238,25 @@ function initSettingsSidebar() {
             settings.pokemonIconSizeModifier = iconSize
             updatePokemons()
             Store.set('pokemonIconSizeModifier', iconSize)
+        })
+
+        $('#filter-by-size-switch').on('change', function () {
+            settings.filterPokemonBySize = this.checked
+            const sizeFilterOptions = $('#filter-by-size-select').closest('.form-control')
+            if (this.checked) {
+                sizeFilterOptions.show()
+            } else {
+                sizeFilterOptions.hide()
+                updateMap({ loadAllPokemon: true })
+            }
+            updatePokemons()
+            Store.set('filterPokemonBySize', this.checked)
+        })
+
+        $('#filter-by-size-select').on('change', function () {
+            settings.filterPokemonBySizeOptions = $(this).val().map(Number)
+            updateMap({ loadAllPokemon: true })
+            Store.set('filterPokemonBySizeOptions', $(this).val().map(Number))
         })
     }
 
@@ -1621,6 +1642,8 @@ function initSettingsSidebar() {
         $('#hundo-ivs-pokemon-switch-wrapper').toggle(settings.maxIvs < 100)
         $('#pokemon-level-slider-title').text(`${i18n('Levels')} (${settings.minLevel} - ${settings.maxLevel})`)
         $('#pokemon-level-slider-wrapper').toggle(settings.filterPokemonByValues)
+        $('#filter-by-size-switch').prop('checked', settings.filterPokemonBySize)
+        $('#filter-by-size-select').val(settings.filterPokemonBySizeOptions)
         if (serverSettings.highlightPokemon) {
             $('#pokemon-highlight-switch').prop('checked', settings.highlightPokemon)
             $('#highlight-pokemon-wrapper').toggle(settings.highlightPokemon)

--- a/static/js/map/map.settings.js
+++ b/static/js/map/map.settings.js
@@ -1644,6 +1644,7 @@ function initSettingsSidebar() {
         $('#pokemon-level-slider-wrapper').toggle(settings.filterPokemonByValues)
         $('#filter-by-size-switch').prop('checked', settings.filterPokemonBySize)
         $('#filter-by-size-select').val(settings.filterPokemonBySizeOptions)
+        $('#filter-by-size-select').closest('.form-control').toggle(settings.filterPokemonBySize)
         if (serverSettings.highlightPokemon) {
             $('#pokemon-highlight-switch').prop('checked', settings.highlightPokemon)
             $('#highlight-pokemon-wrapper').toggle(settings.highlightPokemon)

--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -222,7 +222,7 @@ function getPokemonMapIconUrl(pokemon, generateImages) {
 }
 
 function getSizeDisplay(size) {
-    return pokemonSizes[size] ?? i18n('Unknown Size')
+    return i18n(pokemonSizes[size]) ?? i18n('Unknown Size')
 }
 
 function getIvsPercentage(atk, def, sta) {

--- a/static/js/utils/utils.pokemon.js
+++ b/static/js/utils/utils.pokemon.js
@@ -7,13 +7,15 @@ getMoveName, getMoveType, getMoveTypeNoI8ln, getPokemonGen, getPokemonIds,
 getPokemonLevel, getPokemonNameWithForm, getPokemonRarity,
 getPokemonRarityName, getLocationNearStop, getLocationInCell,
 getPokemonRawIconUrl, getPokemonTypes, initMoveData, initPokemonData,
-searchPokemon, createPokemonMarker, updatePokemonRarities
+searchPokemon, createPokemonMarker, updatePokemonRarities,
+getSizeDisplay
 */
 
 var pokemonData = {}
 var moveData = {}
 var pokemonRarities = {}
 const rarityNames = ['Common', 'Uncommon', 'Rare', 'Very Rare', 'Ultra Rare', 'New Spawn']
+const pokemonSizes = ['Unknown', 'XXS', 'XS', 'M', 'XL', 'XXL']
 // FontAwesome gender classes.
 const genderClasses = ['fa-mars', 'fa-venus', 'fa-neuter']
 var pokemonSearchList = []
@@ -217,6 +219,10 @@ function getPokemonMapIconUrl(pokemon, generateImages) {
         perfectParam = ivs === 100 ? '&perfect=1' : ''
     }
     return `pkm_img?pkm=${pokemon.pokemon_id}${genderParam}${formParam}${costumeParam}${evolutionParam}${weatherParam}${perfectParam}`
+}
+
+function getSizeDisplay(size) {
+    return pokemonSizes[size] ?? i18n('Unknown Size')
 }
 
 function getIvsPercentage(atk, def, sta) {

--- a/static/js/utils/utils.store.js
+++ b/static/js/utils/utils.store.js
@@ -59,6 +59,14 @@ const StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
+    filterPokemonBySize: {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    filterPokemonBySizeOptions: {
+        default: [1, 2, 3, 4, 5],
+        type: StoreTypes.JSON
+    },
     excludedPokemon: {
         default: new Set(),
         type: StoreTypes.Set

--- a/templates/map.html
+++ b/templates/map.html
@@ -694,6 +694,27 @@
                     </div>
                   </div>
                 </div>
+                <div class="form-control">
+                  <div class="switch">
+                    <label>
+                      <input type="checkbox" id="filter-by-size-switch">
+                      <span class="lever"></span>
+                      {{ i18n('Filter by size') }}
+                    </label>
+                  </div>
+                </div>
+                <div class="form-control">
+                  <div class="input-field">
+                    <div class="select-title">{{ i18n('Pokemon Size') }}</div>
+                    <select id="filter-by-size-select" multiple>
+                      <option value="1">{{ i18n('XXS') }}</option>
+                      <option value="2">{{ i18n('XS') }}</option>
+                      <option value="3">{{ i18n('M') }}</option>
+                      <option value="4">{{ i18n('XL') }}</option>
+                      <option value="5">{{ i18n('XXL') }}</option>
+                    </select>
+                  </div>
+                </div>
                 {% if settings.highlightPokemon %}
                 <div class="form-control">
                   <div class="switch">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add size display and filters to RM-async.  This is based on PR 270 (which is for master branch).

## Description
<!--- Describe your changes in detail -->
This pulls size data from the db, displays it in pop-ups, and adds a filter for it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Update the map for new features

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests and feedback welcome.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
