### PR TITLE
Fix routes showing as straight lines on new async raw.

### DIFF
--- a/static/js/map/map.routes.js
+++ b/static/js/map/map.routes.js
@@ -106,11 +106,13 @@ function setupRoutePath(route) {
 
     const wp = JSON.parse(route.waypoints)
     for (let i = 0; i < wp.length; i++) {
-        if (!wp[i].lat_degrees || !wp[i].lng_degrees) {
+        let wp_lat = wp[i].lat_degrees ? wp[i].lat_degrees : wp[i].latDegrees
+        let wp_lng = wp[i].lng_degrees ? wp[i].lng_degrees : wp[i].lngDegrees
+        if (!wp_lat || !wp_lng) {
             console.log('Unknown route waypoint: ', JSON.stringify(wp[i]))
             continue
         }
-        pointLL = new L.latLng(wp[i].lat_degrees, wp[i].lng_degrees)
+        pointLL = new L.latLng(wp_lat, wp_lng)
         routePoints.push(pointLL)
     }
     pointLL = new L.latLng(route.end_poi_latitude, route.end_poi_longitude)


### PR DESCRIPTION
This should support both JSON formats of route waypoints.
The new new (raw) async protos dumps to `latDegrees` rather than `lat_degrees`, etc.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
